### PR TITLE
Handle aiocoap shutdown error

### DIFF
--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -123,3 +123,11 @@ class Command(object):
                     "'{}' and '{}'".format(self.__class__, type(other))
                 )
             )
+
+    def __repr__(self):
+        """Return the representation."""
+        if self.data is None:
+            template = "<Command {} {}{}>"
+        else:
+            template = "<Command {} {}: {}>"
+        return template.format(self.method, self.path, self.data or "")


### PR DESCRIPTION
- aiocoap raises a `LibraryShutdown` error when shutting down.
- Handle this error for observations and command calls.
- Make sure we stop what we're doing when getting the shut down error.
- Also handle `CredentialsMissingError` that I've seen raised when loosing connection to the gateway on shutdown.