### PR TITLE
Reload credentials when the protocol is reset

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -97,19 +97,23 @@ class APIFactory:
             return pr, r
         except CredentialsMissingError as e:
             await self._reset_protocol(e)
+            await self._update_credentials()
             raise ServerError("There was an error with the request.", e)
         except ConstructionRenderableError as e:
             raise ClientError("There was an error with the request.", e)
         except RequestTimedOut as e:
             await self._reset_protocol(e)
+            await self._update_credentials()
             raise RequestTimeout("Request timed out.", e)
         except LibraryShutdown:
             raise
         except Error as e:
             await self._reset_protocol(e)
+            await self._update_credentials()
             raise ServerError("There was an error with the request.", e)
         except asyncio.CancelledError as e:
             await self._reset_protocol(e)
+            await self._update_credentials()
             raise e
 
     async def _execute(self, api_command):


### PR DESCRIPTION
Avoid CredentialsMissingError after a coap request fails.

This PR is the result of https://github.com/home-assistant/core/issues/42563
This change has been tested in this context and solves the described issue.
