### PR TITLE
Do not update credentials when none exist

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -228,6 +228,9 @@ class APIFactory:
 
     async def _update_credentials(self):
         """Update credentials."""
+        if not self._psk:
+            # No credentials to reset
+            return
         protocol = await self._get_protocol()
         protocol.client_credentials.load_from_dict(
             {


### PR DESCRIPTION
In case when  `self._psk` has not been defined yet, do not try to update credentials.