### PR TITLE
Fix observation

### DIFF
--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -108,7 +108,8 @@ async def run():
 
     for light in lights:
         observe_command = light.observe(
-            observe_callback, observe_err_callback, duration=120
+            observe_callback,
+            observe_err_callback,
         )
         # Start observation as a second task on the loop.
         asyncio.ensure_future(api(observe_command))

--- a/examples/example_cover_async.py
+++ b/examples/example_cover_async.py
@@ -111,7 +111,8 @@ async def run():
 
     for blind in blinds:
         observe_command = blind.observe(
-            observe_callback, observe_err_callback, duration=120
+            observe_callback,
+            observe_err_callback,
         )
         # Start observation as a second task on the loop.
         asyncio.ensure_future(api(observe_command))

--- a/examples/example_socket_async.py
+++ b/examples/example_socket_async.py
@@ -106,7 +106,8 @@ async def run():
 
     for socket in sockets:
         observe_command = socket.observe(
-            observe_callback, observe_err_callback, duration=120
+            observe_callback,
+            observe_err_callback,
         )
         # Start observation as a second task on the loop.
         asyncio.ensure_future(api(observe_command))

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -175,11 +175,10 @@ class APIFactory:
 
     async def _observe(self, api_command):
         """Observe an endpoint."""
-        duration = api_command.observe_duration
         url = api_command.url(self._host)
         err_callback = api_command.err_callback
 
-        msg = Message(code=Code.GET, uri=url, observe=duration)
+        msg = Message(code=Code.GET, uri=url, observe=0)
 
         # Note that this is necessary to start observing
         pr, r = await self._get_response(msg)


### PR DESCRIPTION
Fixes #309.

I would suggest considering removing duration completely. It is in general also not sufficient for process handling when using libcoap: users of the api will generally want control when the callback should be cancelled, not specify a timeout upfront.