### PR TITLE
Bump aiocoap from 0.4b3 to 0.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiocoap==0.4b3
+aiocoap==0.4.1
 DTLSSocket==0.1.12
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ VERSION = (PROJECT_DIR / "pytradfri" / "VERSION").read_text().strip()
 GITHUB_URL = "https://github.com/home-assistant-libs/pytradfri"
 DOWNLOAD_URL = f"{GITHUB_URL}/archive/{VERSION}.zip"
 
-EXTRAS_REQUIRE = {"async": ["aiocoap==0.4b3", "DTLSSocket==0.1.12"]}
+EXTRAS_REQUIRE = {"async": ["aiocoap==0.4.1", "DTLSSocket==0.1.12"]}
 
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 


### PR DESCRIPTION
Update aiocoap as there still issues related to tradfri losing its connection occasionally.
I saw the issue re-appear on my own setup, but others have experienced the problem too.
https://github.com/home-assistant/core/issues/42563#issuecomment-849451509

I did a quick sanity check and my lamps still function after upgrading.

Diff: https://github.com/chrysn/aiocoap/compare/0.4b3...0.4.1