### PR TITLE
Removed false await and return self._protocol directly

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -52,8 +52,9 @@ class APIFactory:
     async def _get_protocol(self):
         """Get the protocol for the request."""
         if self._protocol is None:
-            self._protocol = asyncio.create_task(Context.create_client_context())
-        return await self._protocol
+            task = asyncio.create_task(Context.create_client_context())
+            self._protocol = await task
+        return self._protocol
 
     async def _reset_protocol(self, exc=None):
         """Reset the protocol if an error occurs."""


### PR DESCRIPTION
We should not await on self._protocol if the task is terminated, that is potentially causing problems.

I will add a couple of test cases in a future PR.