### PR TITLE
Add mypy and fix existing mypy errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,31 @@
+[mypy]
+python_version = 3.8
+show_error_codes = true
+follow_imports = silent
+ignore_missing_imports = true
+strict_equality = true
+warn_incomplete_stub = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.*]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_subclassing_any = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_untyped_defs = false
+no_implicit_optional = false
+warn_return_any = false
+warn_unreachable = false
+

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -1,7 +1,10 @@
 """COAP implementation using aiocoap."""
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
+from typing import Callable
 
 from aiocoap import Message, Context
 from aiocoap.credentials import CredentialsMissingError
@@ -28,7 +31,7 @@ class APIFactory:
         self._psk = psk
         self._host = host
         self._psk_id = psk_id
-        self._observations_err_callbacks = []
+        self._observations_err_callbacks: list[Callable] = []
         self._protocol = None
         self._reset_lock = asyncio.Lock()
         self._shutdown = False

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ pytest-timeout==1.4.2
 coveralls==3.2.0
 pytest-cov==2.12.1
 black==21.8b0
+mypy==0.910

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.7: py37, lint
+  3.7: py37, lint, typing
   3.8: py38
   3.9: py39
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, lint
+envlist = py37, py38, py39, lint, typing
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -24,3 +24,10 @@ commands =
 deps =
   -rrequirements.txt
   -rrequirements_test.txt
+
+[testenv:typing]
+deps =
+  -rrequirements_test.txt
+commands =
+    mypy pytradfri
+


### PR DESCRIPTION
This is the very first step in making the interface typed, allowing a better control in integration tradfri (HA).

It solved this problem:
homeassistant/components/tradfri/link_pytradfri/api/aiocoap_api.py:31: error: Need type annotation for "_observations_err_callbacks" (hint: "_observations_err_callbacks: List[<type>] = ...")  [var-annotated]

This is tested by having a link to the library within the tradfri integration.