### PR TITLE
Add strict typing part 1

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,3 +29,72 @@ no_implicit_optional = false
 warn_return_any = false
 warn_unreachable = false
 
+# --- strict typing ---
+# one entry pr file.
+# when a directory is converted, file entries are replaced by directory entry
+# when the library is converted, the above entry will be replaced (strict is demanded)
+[mypy-pytradfri.command]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.const]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.error]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.api.__init__]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.device.controller]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-pytradfri.color]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .const import (
     ATTR_LIGHT_COLOR_HEX,
     ATTR_LIGHT_COLOR_X as X,
@@ -41,7 +43,7 @@ COLOR_NAMES = {
 COLORS = {name.lower().replace(" ", "_"): hex for hex, name in COLOR_NAMES.items()}
 
 
-def supported_features(data):
+def supported_features(data: dict[str, str | int]) -> int:
     SUPPORTED_COLOR_FEATURES = 0
 
     if ATTR_LIGHT_DIMMER in data:

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Callable
 TYPE_PROCESS_RESULT_CB = Optional[Callable[[Any], Optional[str]]]
 TYPE_ERR_CB = Optional[Callable[[str], str]]
 
+
 class Command(object):
     """The object for coap commands."""
 
@@ -42,7 +43,7 @@ class Command(object):
         return self._path
 
     @property
-    def data(self) -> Optional[dict[str,Any]]:
+    def data(self) -> Optional[dict[str, Any]]:
         return self._data
 
     @property
@@ -91,7 +92,9 @@ class Command(object):
         """Generate url for coap client."""
         return "coaps://{}:5684/{}".format(host, self.path_str)
 
-    def _merge(self, a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    def _merge(
+        self, a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
         """Merges a into b."""
         if a is None:
             return b

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Optional, Callable
+from typing import Any, Callable, Optional
 
 TYPE_PROCESS_RESULT_CB = Optional[Callable[[Any], Optional[str]]]
 TYPE_ERR_CB = Optional[Callable[[str], str]]
@@ -15,7 +15,7 @@ class Command(object):
         self,
         method: str,
         path: list[str],
-        data: Optional[dict[str, Any]] = None,
+        data: dict[str, Any] | None = None,
         *,
         parse_json: bool = True,
         observe: bool = False,
@@ -31,8 +31,8 @@ class Command(object):
         self._err_callback = err_callback
         self._observe = observe
         self._observe_duration = observe_duration
-        self._raw_result: Optional[str] = None
-        self._result: Optional[str] = None
+        self._raw_result: str | None = None
+        self._result: str | None = None
 
     @property
     def method(self) -> str:
@@ -43,7 +43,7 @@ class Command(object):
         return self._path
 
     @property
-    def data(self) -> Optional[dict[str, Any]]:
+    def data(self) -> dict[str, Any] | None:
         return self._data
 
     @property
@@ -68,11 +68,11 @@ class Command(object):
         return self._observe_duration
 
     @property
-    def raw_result(self) -> Optional[str]:
+    def raw_result(self) -> str | None:
         return self._raw_result
 
     @property
-    def result(self) -> Optional[str]:
+    def result(self) -> str | None:
         return self._result
 
     @result.setter
@@ -93,8 +93,8 @@ class Command(object):
         return "coaps://{}:5684/{}".format(host, self.path_str)
 
     def _merge(
-        self, a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]
-    ) -> Optional[dict[str, Any]]:
+        self, a: dict[str, Any] | None, b: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
         """Merges a into b."""
         if a is None or b is None:
             return None
@@ -112,13 +112,13 @@ class Command(object):
                 b[k] = v
         return b
 
-    def combine_data(self, command2: Optional[Command]) -> None:
+    def combine_data(self, command2: Command | None) -> None:
         """Combines the data for this command with another."""
         if command2 is None:
             return
         self._data = self._merge(command2._data, self._data)
 
-    def __add__(self, other: Optional[Command]) -> Command:
+    def __add__(self, other: Command | None) -> Command:
         if other is None:
             return deepcopy(self)
         if isinstance(other, self.__class__):

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -1,23 +1,27 @@
 """Command implementation."""
+from __future__ import annotations
 
 from copy import deepcopy
+from typing import Any, Optional, Callable
 
+TYPE_PROCESS_RESULT_CB = Optional[Callable[[Any], Optional[str]]]
+TYPE_ERR_CB = Optional[Callable[[str], str]]
 
 class Command(object):
     """The object for coap commands."""
 
     def __init__(
         self,
-        method,
-        path,
-        data=None,
+        method: str,
+        path: list[str],
+        data: Optional[dict[str, Any]] = None,
         *,
-        parse_json=True,
-        observe=False,
-        observe_duration=0,
-        process_result=None,
-        err_callback=None
-    ):
+        parse_json: bool = True,
+        observe: bool = False,
+        observe_duration: int = 0,
+        process_result: TYPE_PROCESS_RESULT_CB = None,
+        err_callback: TYPE_ERR_CB = None
+    ) -> None:
         self._method = method
         self._path = path
         self._data = data
@@ -26,52 +30,52 @@ class Command(object):
         self._err_callback = err_callback
         self._observe = observe
         self._observe_duration = observe_duration
-        self._raw_result = None
-        self._result = None
+        self._raw_result: Optional[str] = None
+        self._result: Optional[str] = None
 
     @property
-    def method(self):
+    def method(self) -> str:
         return self._method
 
     @property
-    def path(self):
+    def path(self) -> list[str]:
         return self._path
 
     @property
-    def data(self):
+    def data(self) -> Optional[dict[str,Any]]:
         return self._data
 
     @property
-    def parse_json(self):
+    def parse_json(self) -> bool:
         return self._parse_json
 
     @property
-    def process_result(self):
+    def process_result(self) -> TYPE_PROCESS_RESULT_CB:
         return self._process_result
 
     @property
-    def err_callback(self):
+    def err_callback(self) -> TYPE_ERR_CB:
         """This will be fired when an observe request fails."""
         return self._err_callback
 
     @property
-    def observe(self):
+    def observe(self) -> bool:
         return self._observe
 
     @property
-    def observe_duration(self):
+    def observe_duration(self) -> int:
         return self._observe_duration
 
     @property
-    def raw_result(self):
+    def raw_result(self) -> Optional[str]:
         return self._raw_result
 
     @property
-    def result(self):
+    def result(self) -> Optional[str]:
         return self._result
 
     @result.setter
-    def result(self, value):
+    def result(self, value: str) -> None:
         """The result of the command."""
         if self._process_result:
             self._result = self._process_result(value)
@@ -83,12 +87,16 @@ class Command(object):
         """Return coap path."""
         return "/".join(str(v) for v in self._path)
 
-    def url(self, host):
+    def url(self, host: str) -> str:
         """Generate url for coap client."""
         return "coaps://{}:5684/{}".format(host, self.path_str)
 
-    def _merge(self, a, b):
+    def _merge(self, a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
         """Merges a into b."""
+        if a is None:
+            return b
+        if b is None:
+            return b
         for k, v in a.items():
             if isinstance(v, dict):
                 item = b.setdefault(k, {})
@@ -103,13 +111,13 @@ class Command(object):
                 b[k] = v
         return b
 
-    def combine_data(self, command2):
+    def combine_data(self, command2: Optional[Command]) -> None:
         """Combines the data for this command with another."""
         if command2 is None:
             return
         self._data = self._merge(command2._data, self._data)
 
-    def __add__(self, other):
+    def __add__(self, other: Optional[Command]) -> Command:
         if other is None:
             return deepcopy(self)
         if isinstance(other, self.__class__):
@@ -124,7 +132,7 @@ class Command(object):
                 )
             )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the representation."""
         if self.data is None:
             template = "<Command {} {}{}>"

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -96,10 +96,8 @@ class Command(object):
         self, a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]
     ) -> Optional[dict[str, Any]]:
         """Merges a into b."""
-        if a is None:
-            return b
-        if b is None:
-            return b
+        if a is None or b is None:
+            return None
         for k, v in a.items():
             if isinstance(v, dict):
                 item = b.setdefault(k, {})

--- a/pytradfri/device/controller.py
+++ b/pytradfri/device/controller.py
@@ -1,10 +1,13 @@
 """Base class for a controller."""
 from __future__ import annotations
 
+
 class Controller:
     """Represent a controller."""
 
-    def _value_validate(self, value: int, rnge: list[int], identifier: str = "Given") -> None:
+    def _value_validate(
+        self, value: int, rnge: list[int], identifier: str = "Given"
+    ) -> None:
         """
         Make sure a value is within a given range
         """

--- a/pytradfri/device/controller.py
+++ b/pytradfri/device/controller.py
@@ -1,10 +1,10 @@
 """Base class for a controller."""
-
+from __future__ import annotations
 
 class Controller:
     """Represent a controller."""
 
-    def _value_validate(self, value, rnge, identifier="Given"):
+    def _value_validate(self, value: int, rnge: list[int], identifier: str = "Given") -> None:
         """
         Make sure a value is within a given range
         """


### PR DESCRIPTION
The files are not selected by random, I have made a dependency tree, and the files in this PR depend on nothing or on each other and therefore can be converted without needing to change other files.

The most important file is command.py, with a lot of changes that affect the bulk of the library as well as external use, this file need an extra careful review please.

In order to control that command.py is typed correctly, I have converted around 50% of the library and the findings flowed back into command.py. I have marked a number of code changes for a later PR, since I do not want to mix "themes".

Once this PR is corrected and merged, I will adapt the changes in the next batch and submit it. A batch is defined as:
- files that only depend on each other or already converted files
- the number of changes are below 200
- preferable only one file with complicated conversion

I can easily adapt the batch definition and submit depending on your preference.

