### PR TITLE
Add .pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,6 @@ repos:
         name: flake8
         stages: [manual]
 # DO NOT ACTIVATE until all files have been manually updated.
-        additional_dependencies:
-          - pycodestyle==2.7.0
-          - pyflakes==2.3.1
-          - flake8-docstrings==1.6.0
-          - pydocstyle==6.0.0
-          - flake8-comprehensions==3.5.0
-          - flake8-noqa==1.1.0
-          - mccabe==0.6.1
         files: ^(pytradfri|examples|tests)/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+        name: black
+        args:
+          - --safe
+          - --quiet
+        files: ^((pytradfri|examples|tests)/.+)?[^/]+\.py$
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        name: flake8
+        stages: [manual]
+# DO NOT ACTIVATE until all files have been manually updated.
+        additional_dependencies:
+          - pycodestyle==2.7.0
+          - pyflakes==2.3.1
+          - flake8-docstrings==1.6.0
+          - pydocstyle==6.0.0
+          - flake8-comprehensions==3.5.0
+          - flake8-noqa==1.1.0
+          - mccabe==0.6.1
+        files: ^(pytradfri|examples|tests)/.+\.py$
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        name: isort
+        stages: [manual]
+# DO NOT ACTIVATE until PR 340 have been merged.
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        stages: [manual]
+# DO NOT ACTIVATE until all files have been manually updated.
+        entry: pylint
+        language: system
+        types: [python]
+        files: ^(pytradfri|examples|tests)/.+\.py$
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        args:
+          - --timeout=30
+          - --cov=pytradfri
+          - --cov-report=html
+        entry: pytest
+        language: system
+        types: [python]
+        files: tests
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: ./script/run-pre-commit.sh mypy
+        language: script
+        types: [python]
+        require_serial: true
+#        files: ^(pytradfri|examples|tests)/.+\.py$
+# DO NOT ADD examples/tests until files have been updated.
+        files: ^(pytradfri)/.+\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
         args:
           - --safe
           - --quiet
-        files: ^((pytradfri|examples|tests)/.+)?[^/]+\.py$
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
           - --timeout=30
           - --cov=pytradfri
           - --cov-report=html
+        stages: [push,manual]
         entry: pytest
         language: system
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ combine_as_imports = true
 [tool.pylint.MASTER]
 py-version = "3.8"
 ignore = [
-    "tests",
 ]
 # Use a conservative default here; 2 should speed up most setups and not hurt
 # any too bad. Override on command line as appropriate.
@@ -30,24 +29,13 @@ load-plugins = [
     "pylint.extensions.code_style",
     "pylint.extensions.typing",
     "pylint_strict_informational",
-    "hass_constructor",
-    "hass_imports",
-    "hass_logger",
 ]
 persistent = false
-extension-pkg-allow-list = [
-    "av.audio.stream",
-    "av.stream",
-    "ciso8601",
-    "cv2",
-]
 
 [tool.pylint.BASIC]
 class-const-naming-style = "any"
 good-names = [
     "_",
-    "ev",
-    "ex",
     "fp",
     "i",
     "id",
@@ -78,16 +66,16 @@ good-names = [
 # consider-using-assignment-expr (Pylint CodeStyle extension)
 disable = [
     "format",
-    "abstract-class-little-used",
+#    "abstract-class-little-used",
     "abstract-method",
     "cyclic-import",
     "duplicate-code",
-    "inconsistent-return-statements",
-    "locally-disabled",
+#    "inconsistent-return-statements",
+#    "locally-disabled",
     "not-context-manager",
     "too-few-public-methods",
     "too-many-ancestors",
-    "too-many-arguments",
+#    "too-many-arguments",
     "too-many-branches",
     "too-many-instance-attributes",
     "too-many-lines",
@@ -98,9 +86,9 @@ disable = [
     "too-many-boolean-expressions",
     "unused-argument",
     "wrong-import-order",
-    "consider-using-f-string",
-    "consider-using-namedtuple-or-dataclass",
-    "consider-using-assignment-expr",
+#    "consider-using-f-string",
+#    "consider-using-namedtuple-or-dataclass",
+#    "consider-using-assignment-expr",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up
@@ -110,11 +98,6 @@ enable = [
 [tool.pylint.REPORTS]
 score = false
 
-[tool.pylint.TYPECHECK]
-ignored-classes = [
-    "_CountingAttr",  # for attrs
-]
-
 [tool.pylint.FORMAT]
 expected-line-ending-format = "LF"
 
@@ -122,7 +105,6 @@ expected-line-ending-format = "LF"
 overgeneral-exceptions = [
     "BaseException",
     "Exception",
-    "HomeAssistantError",
 ]
 
 [tool.pylint.TYPING]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 target-version = ["py38"]
 exclude = 'generated,.tox'
+include = '^((pytradfri|examples|tests)/.+)?[^/]+\.py$'
 
 [tool.isort]
 # https://github.com/PyCQA/isort/wiki/isort-Settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 target-version = ["py38"]
-exclude = 'generated'
+exclude = 'generated,.tox'
 
 [tool.isort]
 # https://github.com/PyCQA/isort/wiki/isort-Settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.black]
+target-version = ["py38"]
+exclude = 'generated'
+
 [tool.isort]
 # https://github.com/PyCQA/isort/wiki/isort-Settings
 profile = "black"
@@ -12,3 +16,125 @@ forced_separate = [
 ]
 combine_as_imports = true
 
+[tool.pylint.MASTER]
+py-version = "3.8"
+ignore = [
+    "tests",
+]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook='from pylint.config.find_default_config_files import find_default_config_files; from pathlib import Path; import sys; sys.path.append(str(Path(Path(list(find_default_config_files())[0]).parent, "pylint/plugins")))'
+load-plugins = [
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+    "pylint_strict_informational",
+    "hass_constructor",
+    "hass_imports",
+    "hass_logger",
+]
+persistent = false
+extension-pkg-allow-list = [
+    "av.audio.stream",
+    "av.stream",
+    "ciso8601",
+    "cv2",
+]
+
+[tool.pylint.BASIC]
+class-const-naming-style = "any"
+good-names = [
+    "_",
+    "ev",
+    "ex",
+    "fp",
+    "i",
+    "id",
+    "j",
+    "k",
+    "Run",
+    "T",
+]
+
+[tool.pylint."MESSAGES CONTROL"]
+# Reasons disabled:
+# format - handled by black
+# locally-disabled - it spams too much
+# duplicate-code - unavoidable
+# cyclic-import - doesn't test if both import on load
+# abstract-class-little-used - prevents from setting right foundation
+# unused-argument - generic callbacks and setup methods create a lot of warnings
+# too-many-* - are not enforced for the sake of readability
+# too-few-* - same as too-many-*
+# abstract-method - with intro of async there are always methods missing
+# inconsistent-return-statements - doesn't handle raise
+# too-many-ancestors - it's too strict.
+# wrong-import-order - isort guards this
+# consider-using-f-string - str.format sometimes more readable
+# ---
+# Enable once current issues are fixed:
+# consider-using-namedtuple-or-dataclass (Pylint CodeStyle extension)
+# consider-using-assignment-expr (Pylint CodeStyle extension)
+disable = [
+    "format",
+    "abstract-class-little-used",
+    "abstract-method",
+    "cyclic-import",
+    "duplicate-code",
+    "inconsistent-return-statements",
+    "locally-disabled",
+    "not-context-manager",
+    "too-few-public-methods",
+    "too-many-ancestors",
+    "too-many-arguments",
+    "too-many-branches",
+    "too-many-instance-attributes",
+    "too-many-lines",
+    "too-many-locals",
+    "too-many-public-methods",
+    "too-many-return-statements",
+    "too-many-statements",
+    "too-many-boolean-expressions",
+    "unused-argument",
+    "wrong-import-order",
+    "consider-using-f-string",
+    "consider-using-namedtuple-or-dataclass",
+    "consider-using-assignment-expr",
+]
+enable = [
+    #"useless-suppression",  # temporarily every now and then to clean them up
+    "use-symbolic-message-instead",
+]
+
+[tool.pylint.REPORTS]
+score = false
+
+[tool.pylint.TYPECHECK]
+ignored-classes = [
+    "_CountingAttr",  # for attrs
+]
+
+[tool.pylint.FORMAT]
+expected-line-ending-format = "LF"
+
+[tool.pylint.EXCEPTIONS]
+overgeneral-exceptions = [
+    "BaseException",
+    "Exception",
+    "HomeAssistantError",
+]
+
+[tool.pylint.TYPING]
+runtime-typing = false
+
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+norecursedirs = [
+    ".git",
+    "testing_config",
+]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,11 @@ pytest-cov==2.12.1
 black==21.9b0
 mypy==0.910
 pre-commit==2.14.0
+pycodestyle==2.7.0
+pyflakes==2.3.1
+flake8-docstrings==1.6.0
+pydocstyle==6.0.0
+flake8-comprehensions==3.5.0
+flake8-noqa==1.1.0
+mccabe==0.6.1
+

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ coveralls==3.2.0
 pytest-cov==2.12.1
 black==21.9b0
 mypy==0.910
+pre-commit==2.14.0

--- a/script/run-pre-commit.sh
+++ b/script/run-pre-commit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+exec "$@"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,20 @@ ignore =
     E203,
     D202,
     W504,
-    E402
+    E402,
+# Ignore to secure identical run tox/pre-commit and behaviour like before installing plugins
+# these errors are to be corrected in the code
+    C416,
+    D100,
+    D101,
+    D102,
+    D103,
+    D104,
+    D105,
+    D107,
+    D200,
+    D205,
+    D209,
+    D400,
+    D401,
+    NQA101


### PR DESCRIPTION
This PR adds but do not activate the pre-commit hooks, similar (but reduced) to HA.

It runs black/flake8/isort/mypy

to activate it run:
pre-commit install

However especially black and flake8 made a lot of corrections, so these needs to be merged first, and then githooks will be activated (saving time by not getting surprises from CI).