### PR TITLE
Bump flake8 to 4.0.1

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 pytest==6.2.5
-flake8==3.9.2
+flake8==4.0.1
 pytest-timeout==2.0.0
 coveralls==3.2.0
 pytest-cov==3.0.0
@@ -7,6 +7,6 @@ black==21.9b0
 mypy==0.910
 pre-commit==2.15.0
 flake8-docstrings==1.6.0
-flake8-comprehensions==3.6.1
-flake8-noqa==1.1.0
+flake8-comprehensions==3.7.0
+flake8-noqa==1.2.0
 


### PR DESCRIPTION
Saw flake8-comprehensions and noqa have new versions, so let try.

flake8-noqa, do not have a CHANGELOG, so link to history:
https://pypi.org/project/flake8-noqa/#history

3.6.1: https://github.com/adamchainz/flake8-comprehensions/blob/main/HISTORY.rst#361-2021-08-16
3.7.0: https://github.com/adamchainz/flake8-comprehensions/blob/main/HISTORY.rst#370-2021-10-11

flake8 do not have a CHANGELOG, so link to history:
https://pypi.org/project/flake8/#history
