### PR TITLE
Add communication debug

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -184,7 +184,7 @@ class APIFactory:
                 api_msg += f"<<<{vars(api_command)}>>>"
             else:
                 api_msg += f"+++{api_commands}+++"
-        msg = f"DUMP-REQUEST{call_type}: {self._host} {api_msg}"
+        msg = f"REQUEST {call_type}: {self._host} {api_msg}"
         _LOGGER.debug(msg)
 
     async def request(self, api_commands):


### PR DESCRIPTION
Add debug of what send/reponse to/from the external library. This output
is used to feed mock_api (new PR), allowing us to reproduce real life user
situations (apart from timing).

Being able to reproduce user setups, will make it easier to locate problems, and most of all to test equipment not available.

