### PR TITLE
Force timeout of requests

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -114,7 +114,7 @@ class APIFactory:
         except asyncio.TimeoutError as e:
             await self._reset_protocol(e)
             await self._update_credentials()
-            raise RequestTimeout("Request was timed out.", e)
+            raise RequestTimeout("Request timed out.", e)
         except RequestTimedOut as e:
             await self._reset_protocol(e)
             await self._update_credentials()


### PR DESCRIPTION
If the gateway is offline, requests accumulate for a long time, and if the gateway goes online again with half an hour (not exactly measured) all the accumulated requests are sent leading to an “overload” of the gateway.

aiocoap timeout is not definable, and does not always work, so use
"wait_for" when calling to provoke a forced timeout.