### PR TITLE
Clean and fix tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,6 +29,9 @@ no_implicit_optional = false
 warn_return_any = false
 warn_unreachable = false
 
+[mypy-tests.*]
+ignore_errors = true
+
 # --- strict typing ---
 # one entry pr file.
 # when a directory is converted, file entries are replaced by directory entry

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Test the api."""


### PR DESCRIPTION
- Fix incorrect tests that didn't run correctly due to incorrect logic in the tests.
- Make sure to copy constant fixture data before modifying it in tests and do it before instantiating test targets.
- Add missing test package module.
- Ignore mypy errors for tests.