### PR TITLE
fix if-expression for user-id check

### DIFF
--- a/script/install-coap-client.sh
+++ b/script/install-coap-client.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$EUID" -ne 0 ]
+if [ $(id -u) -ne 0 ]
   then echo "Please run the script as: sudo ./install-coap-client.sh"
   exit
 fi


### PR DESCRIPTION
Hi there,

If run via "/bin/sh" (instead of "/bin/bash") the first if-expression of that script will always fail with...

```
./install-coap-client.sh: 3: [: Illegal number: 
```

... because you're comparing a string with an integer.

`$(id -u)` should be used instead.

Thanks.