### PR TITLE
Fix observation err_callback typing

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -16,6 +16,7 @@ from aiocoap.error import (
 )
 from aiocoap.numbers.codes import Code
 
+from ..command import Command
 from ..error import ClientError, RequestTimeout, ServerError
 from ..gateway import Gateway
 
@@ -205,7 +206,7 @@ class APIFactory:
         self.debug_comm("return", command_results)
         return command_results
 
-    async def _observe(self, api_command, timeout):
+    async def _observe(self, api_command: Command, timeout: float | None) -> None:
         """Observe an endpoint."""
         duration = api_command.observe_duration
         url = api_command.url(self._host)
@@ -221,11 +222,12 @@ class APIFactory:
         def success_callback(res):
             api_command.result = _process_output(res)
 
-        def error_callback(exc):
+        def error_callback(exc: Exception) -> None:
             if isinstance(exc, LibraryShutdown):
                 _LOGGER.debug("Protocol is shutdown, stopping observation")
                 return
-            err_callback(exc)
+            if err_callback:
+                err_callback(exc)
 
         observation = pr_req.observation
         observation.register_callback(success_callback)

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from typing import Any, Callable, Optional
 
 TypeProcessResultCb = Optional[Callable[[Any], Optional[str]]]
-TypeErrCb = Optional[Callable[[str], str]]
 
 
 class Command:
@@ -21,7 +20,7 @@ class Command:
         observe: bool = False,
         observe_duration: int = 0,
         process_result: TypeProcessResultCb = None,
-        err_callback: TypeErrCb = None,
+        err_callback: Callable[[Exception], None] | None = None,
     ) -> None:
         """Create object of class."""
         self._method = method
@@ -61,7 +60,7 @@ class Command:
         return self._process_result
 
     @property
-    def err_callback(self) -> TypeErrCb:
+    def err_callback(self) -> Callable[[Exception], None] | None:
         """Will be fired when an observe request fails."""
         return self._err_callback
 

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Callable, Dict, List, Union, cast
 
-from .command import Command, TypeErrCb, TypeProcessResultCb
+from .command import Command, TypeProcessResultCb
 from .const import ATTR_CREATED_AT, ATTR_ID, ATTR_NAME
 
 # type alias
@@ -47,7 +47,7 @@ class ApiResource:
     def observe(
         self,
         callback: TypeProcessResultCb,
-        err_callback: TypeErrCb | None,
+        err_callback: Callable[[Exception], None] | None,
         duration: int = 60,
     ) -> Command:
         """Observe resource and call callback when updated."""


### PR DESCRIPTION
- The type annotation for the observation error callback was incorrect. Fix that.
- I needed to fix and some additional things around the observation method in the APIs to correct typing after the error callback fix.