### PR TITLE
Add type annotation for Blind class

### DIFF
--- a/pytradfri/device/blind.py
+++ b/pytradfri/device/blind.py
@@ -1,14 +1,25 @@
 """Represent a blind."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from ..const import ATTR_BLIND_CURRENT_POSITION, ATTR_START_BLINDS
-from ..resource import TypeRaw, TypeRawList
+from ..resource import TypeRawList
 
 if TYPE_CHECKING:
     # avoid cyclic import at runtime.
     from . import Device
+
+
+TypeBlind = TypedDict(
+    # Alternative syntax required due to the need of using strings as keys:
+    # https://www.python.org/dev/peps/pep-0589/#alternative-syntax
+    "TypeBlind",
+    {
+        "5536": int,  # Current blind position
+        "9003": int,  # ID
+    },
+)
 
 
 class Blind:
@@ -20,14 +31,14 @@ class Blind:
         self.index = index
 
     @property
-    def raw(self) -> TypeRaw:
+    def raw(self) -> TypeBlind:
         """Return raw data that it represents."""
         return cast(
-            TypeRaw,
+            TypeBlind,
             cast(TypeRawList, self.device.raw)[ATTR_START_BLINDS][self.index],
         )
 
     @property
     def current_cover_position(self) -> int:
         """Get the current position of the blind."""
-        return cast(int, self.raw.get(ATTR_BLIND_CURRENT_POSITION))
+        return self.raw[ATTR_BLIND_CURRENT_POSITION]


### PR DESCRIPTION
This PR implements a `TypedDict` for the `Blind` class.