### PR TITLE
Type hints for ApiResource

### DIFF
--- a/pytradfri/device/__init__.py
+++ b/pytradfri/device/__init__.py
@@ -1,6 +1,6 @@
 """Classes to interact with devices."""
 from datetime import datetime
-from typing import Optional, TypedDict, cast
+from typing import Optional
 
 from ..const import (
     ATTR_APPLICATION_TYPE,
@@ -21,26 +21,12 @@ from ..const import (
     ROOT_SIGNAL_REPEATER,
 )
 from ..resource import ApiResource
+from ..typing import TypeDeviceInfo
 from .air_purifier_control import AirPurifierControl
 from .blind_control import BlindControl
 from .light_control import LightControl
 from .signal_repeater_control import SignalRepeaterControl
 from .socket_control import SocketControl
-
-TypeDeviceInfo = TypedDict(
-    # Alternative syntax required due to the need of using strings as keys:
-    # https://www.python.org/dev/peps/pep-0589/#alternative-syntax
-    "TypeDeviceInfo",
-    {
-        "0": str,  # Manufacturer
-        "1": str,  # Model number
-        "2": str,  # Serial number
-        "3": str,  # Firmware version
-        "6": int,  # Power source
-        "7": str,  # OTA image type
-        "9": int,  # Battery level
-    },
-)
 
 
 class Device(ApiResource):
@@ -200,4 +186,4 @@ class DeviceInfo:
     @property
     def raw(self) -> TypeDeviceInfo:
         """Return raw data that it represents."""
-        return cast(TypeDeviceInfo, self._device.raw[ATTR_DEVICE_INFO])
+        return self._device.raw[ATTR_DEVICE_INFO]

--- a/pytradfri/device/__init__.py
+++ b/pytradfri/device/__init__.py
@@ -21,7 +21,7 @@ from ..const import (
     ROOT_SIGNAL_REPEATER,
 )
 from ..resource import ApiResource
-from ..typing import TypeDeviceInfo
+from ..typing import DeviceInfoResponse
 from .air_purifier_control import AirPurifierControl
 from .blind_control import BlindControl
 from .light_control import LightControl
@@ -184,6 +184,6 @@ class DeviceInfo:
         return self.raw[ATTR_DEVICE_BATTERY]
 
     @property
-    def raw(self) -> TypeDeviceInfo:
+    def raw(self) -> DeviceInfoResponse:
         """Return raw data that it represents."""
         return self._device.raw[ATTR_DEVICE_INFO]

--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -1,7 +1,7 @@
 """Represent an air purifier."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING
 
 from ..const import (
     ATTR_AIR_PURIFIER_AIR_QUALITY,
@@ -17,31 +17,11 @@ from ..const import (
     ATTR_AIR_PURIFIER_MOTOR_RUNTIME_TOTAL,
     ROOT_AIR_PURIFIER,
 )
-from ..resource import TypeRawList
+from ..typing import TypeAirPurifier
 
 if TYPE_CHECKING:
     # avoid cyclic import at runtime.
     from . import Device
-
-
-TypeAirPurifier = TypedDict(
-    # Alternative syntax required due to the need of using strings as keys:
-    # https://www.python.org/dev/peps/pep-0589/#alternative-syntax
-    "TypeAirPurifier",
-    {
-        "5900": int,  # Mode
-        "5902": int,  # Filter runtume
-        "5903": int,  # Filter status
-        "5904": int,  # Filter lifetime total
-        "5905": int,  # Manual controls locked
-        "5906": int,  # Led light on/off
-        "5907": int,  # Air quality level
-        "5908": int,  # Fan speed
-        "5909": int,  # Motor runtime total
-        "5910": int,  # Filter lifetime remaining
-        "9003": int,  # ID
-    },
-)
 
 
 class AirPurifier:
@@ -119,10 +99,7 @@ class AirPurifier:
     @property
     def raw(self) -> TypeAirPurifier:
         """Return raw data that it represents."""
-        return cast(
-            TypeAirPurifier,
-            cast(TypeRawList, self.device.raw)[ROOT_AIR_PURIFIER][self.index],
-        )
+        return self.device.raw[ROOT_AIR_PURIFIER][self.index]
 
     @property
     def state(self) -> bool:

--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -17,7 +17,7 @@ from ..const import (
     ATTR_AIR_PURIFIER_MOTOR_RUNTIME_TOTAL,
     ROOT_AIR_PURIFIER,
 )
-from ..typing import TypeAirPurifier
+from ..typing import AirPurifierResponse
 
 if TYPE_CHECKING:
     # avoid cyclic import at runtime.
@@ -97,7 +97,7 @@ class AirPurifier:
         return self.raw[ATTR_AIR_PURIFIER_MOTOR_RUNTIME_TOTAL]
 
     @property
-    def raw(self) -> TypeAirPurifier:
+    def raw(self) -> AirPurifierResponse:
         """Return raw data that it represents."""
         return self.device.raw[ROOT_AIR_PURIFIER][self.index]
 

--- a/pytradfri/device/blind.py
+++ b/pytradfri/device/blind.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..const import ATTR_BLIND_CURRENT_POSITION, ATTR_START_BLINDS
-from ..typing import TypeBlind
+from ..typing import BlindResponse
 
 if TYPE_CHECKING:
     # avoid cyclic import at runtime.
@@ -20,7 +20,7 @@ class Blind:
         self.index = index
 
     @property
-    def raw(self) -> TypeBlind:
+    def raw(self) -> BlindResponse:
         """Return raw data that it represents."""
         return self.device.raw[ATTR_START_BLINDS][self.index]
 

--- a/pytradfri/device/blind.py
+++ b/pytradfri/device/blind.py
@@ -1,10 +1,10 @@
 """Represent a blind."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from ..const import ATTR_BLIND_CURRENT_POSITION, ATTR_START_BLINDS
-from ..resource import TypeRaw, TypeRawList
+from ..typing import TypeBlind
 
 if TYPE_CHECKING:
     # avoid cyclic import at runtime.
@@ -20,14 +20,11 @@ class Blind:
         self.index = index
 
     @property
-    def raw(self) -> TypeRaw:
+    def raw(self) -> TypeBlind:
         """Return raw data that it represents."""
-        return cast(
-            TypeRaw,
-            cast(TypeRawList, self.device.raw)[ATTR_START_BLINDS][self.index],
-        )
+        return self.device.raw[ATTR_START_BLINDS][self.index]
 
     @property
     def current_cover_position(self) -> int:
         """Get the current position of the blind."""
-        return cast(int, self.raw.get(ATTR_BLIND_CURRENT_POSITION))
+        return self.raw[ATTR_BLIND_CURRENT_POSITION]

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -1,11 +1,13 @@
 """Resources for devices."""
 from __future__ import annotations
 
+from abc import abstractmethod
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Union, cast
+from typing import Any, Callable, Dict, List, Union
 
 from .command import Command, TypeProcessResultCb
 from .const import ATTR_CREATED_AT, ATTR_ID, ATTR_NAME
+from .typing import TypeApiResource
 
 # type alias
 TypeRaw = Dict[str, Union[str, int, List[Dict[str, Union[str, int]]]]]
@@ -16,33 +18,31 @@ TypeRawList = Dict[str, List[Dict[str, Union[str, int]]]]
 class ApiResource:
     """Base object for resources returned from the gateway."""
 
-    def __init__(self, raw: TypeRaw) -> None:
+    def __init__(self, raw: TypeApiResource) -> None:
         """Initialize base object."""
         self.raw = raw
 
     @property
     def id(self) -> str | None:
         """Id."""
-        return cast(Union[str, None], self.raw.get(ATTR_ID))
+        return self.raw[ATTR_ID]
 
     @property
     def name(self) -> str | None:
         """Name."""
-        return cast(Union[str, None], self.raw.get(ATTR_NAME))
+        return self.raw[ATTR_NAME]
 
     @property
     def created_at(self) -> datetime | None:
         """Return timestamp of creation."""
         if ATTR_CREATED_AT not in self.raw:
             return None
-        return datetime.utcfromtimestamp(
-            int(cast(TypeRawSimple, self.raw)[ATTR_CREATED_AT])
-        )
+        return datetime.utcfromtimestamp(self.raw[ATTR_CREATED_AT])
 
     @property
+    @abstractmethod
     def path(self) -> list[str]:
         """Path to resource."""
-        raise NotImplementedError("Path property needs to be implemented")
 
     def observe(
         self,
@@ -52,7 +52,7 @@ class ApiResource:
     ) -> Command:
         """Observe resource and call callback when updated."""
 
-        def observe_callback(value: TypeRaw) -> None:
+        def observe_callback(value: TypeApiResource) -> None:
             """Call when end point is updated.
 
             Returns a Command.
@@ -89,7 +89,7 @@ class ApiResource:
         Returns a Command.
         """
 
-        def process_result(result: TypeRaw) -> None:
+        def process_result(result: TypeApiResource) -> None:
             self.raw = result
 
         return Command("get", self.path, process_result=process_result)

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Union
 
 from .command import Command, TypeProcessResultCb
 from .const import ATTR_CREATED_AT, ATTR_ID, ATTR_NAME
-from .typing import TypeApiResource
+from .typing import ApiResourceResponse
 
 # type alias
 TypeRaw = Dict[str, Union[str, int, List[Dict[str, Union[str, int]]]]]
@@ -18,7 +18,7 @@ TypeRawList = Dict[str, List[Dict[str, Union[str, int]]]]
 class ApiResource:
     """Base object for resources returned from the gateway."""
 
-    def __init__(self, raw: TypeApiResource) -> None:
+    def __init__(self, raw: ApiResourceResponse) -> None:
         """Initialize base object."""
         self.raw = raw
 
@@ -52,7 +52,7 @@ class ApiResource:
     ) -> Command:
         """Observe resource and call callback when updated."""
 
-        def observe_callback(value: TypeApiResource) -> None:
+        def observe_callback(value: ApiResourceResponse) -> None:
             """Call when end point is updated.
 
             Returns a Command.
@@ -89,7 +89,7 @@ class ApiResource:
         Returns a Command.
         """
 
-        def process_result(result: TypeApiResource) -> None:
+        def process_result(result: ApiResourceResponse) -> None:
             self.raw = result
 
         return Command("get", self.path, process_result=process_result)

--- a/pytradfri/typing.py
+++ b/pytradfri/typing.py
@@ -6,20 +6,6 @@ as keys: https://www.python.org/dev/peps/pep-0589/#alternative-syntax
 """
 from typing import List, TypedDict
 
-TypeDeviceInfo = TypedDict(
-    "TypeDeviceInfo",
-    {
-        "0": str,  # Manufacturer
-        "1": str,  # Model number
-        "2": str,  # Serial number
-        "3": str,  # Firmware version
-        "6": int,  # Power source
-        "7": str,  # OTA image type
-        "9": int,  # Battery level
-    },
-)
-
-
 TypeAirPurifier = TypedDict(
     "TypeAirPurifier",
     {
@@ -42,6 +28,19 @@ TypeBlind = TypedDict(
     {
         "5536": int,  # Current blind position
         "9003": int,  # ID
+    },
+)
+
+TypeDeviceInfo = TypedDict(
+    "TypeDeviceInfo",
+    {
+        "0": str,  # Manufacturer
+        "1": str,  # Model number
+        "2": str,  # Serial number
+        "3": str,  # Firmware version
+        "6": int,  # Power source
+        "7": str,  # OTA image type
+        "9": int,  # Battery level
     },
 )
 

--- a/pytradfri/typing.py
+++ b/pytradfri/typing.py
@@ -23,8 +23,8 @@ AirPurifierResponse = TypedDict(
     },
 )
 
-TypeBlindResponse = TypedDict(
-    "TypeBlindResponse",
+BlindResponse = TypedDict(
+    "BlindResponse",
     {
         "5536": int,  # Current blind position
         "9003": int,  # ID
@@ -53,6 +53,6 @@ ApiResourceResponse = TypedDict(
         "9003": str,  # ID
         "3": DeviceInfoResponse,
         "15025": List[AirPurifierResponse],
-        "15015": List[TypeBlindResponse],
+        "15015": List[BlindResponse],
     },
 )

--- a/pytradfri/typing.py
+++ b/pytradfri/typing.py
@@ -1,0 +1,59 @@
+"""
+Type hints.
+
+The TypedDict:s below uses an alternative syntax due to the need of using strings
+as keys: https://www.python.org/dev/peps/pep-0589/#alternative-syntax
+"""
+from typing import List, TypedDict
+
+TypeDeviceInfo = TypedDict(
+    "TypeDeviceInfo",
+    {
+        "0": str,  # Manufacturer
+        "1": str,  # Model number
+        "2": str,  # Serial number
+        "3": str,  # Firmware version
+        "6": int,  # Power source
+        "7": str,  # OTA image type
+        "9": int,  # Battery level
+    },
+)
+
+
+TypeAirPurifier = TypedDict(
+    "TypeAirPurifier",
+    {
+        "5900": int,  # Mode
+        "5902": int,  # Filter runtume
+        "5903": int,  # Filter status
+        "5904": int,  # Filter lifetime total
+        "5905": int,  # Manual controls locked
+        "5906": int,  # Led light on/off
+        "5907": int,  # Air quality level
+        "5908": int,  # Fan speed
+        "5909": int,  # Motor runtime total
+        "5910": int,  # Filter lifetime remaining
+        "9003": int,  # ID
+    },
+)
+
+TypeBlind = TypedDict(
+    "TypeBlind",
+    {
+        "5536": int,  # Current blind position
+        "9003": int,  # ID
+    },
+)
+
+
+TypeApiResource = TypedDict(
+    "TypeApiResource",
+    {
+        "9001": str,  # Name
+        "9002": int,  # Created at
+        "9003": str,  # ID
+        "3": TypeDeviceInfo,
+        "15025": List[TypeAirPurifier],
+        "15015": List[TypeBlind],
+    },
+)

--- a/pytradfri/typing.py
+++ b/pytradfri/typing.py
@@ -6,8 +6,8 @@ as keys: https://www.python.org/dev/peps/pep-0589/#alternative-syntax
 """
 from typing import List, TypedDict
 
-TypeAirPurifier = TypedDict(
-    "TypeAirPurifier",
+AirPurifierResponse = TypedDict(
+    "AirPurifierResponse",
     {
         "5900": int,  # Mode
         "5902": int,  # Filter runtume
@@ -23,16 +23,16 @@ TypeAirPurifier = TypedDict(
     },
 )
 
-TypeBlind = TypedDict(
-    "TypeBlind",
+TypeBlindResponse = TypedDict(
+    "TypeBlindResponse",
     {
         "5536": int,  # Current blind position
         "9003": int,  # ID
     },
 )
 
-TypeDeviceInfo = TypedDict(
-    "TypeDeviceInfo",
+DeviceInfoResponse = TypedDict(
+    "DeviceInfoResponse",
     {
         "0": str,  # Manufacturer
         "1": str,  # Model number
@@ -45,14 +45,14 @@ TypeDeviceInfo = TypedDict(
 )
 
 
-TypeApiResource = TypedDict(
-    "TypeApiResource",
+ApiResourceResponse = TypedDict(
+    "ApiResourceResponse",
     {
         "9001": str,  # Name
         "9002": int,  # Created at
         "9003": str,  # ID
-        "3": TypeDeviceInfo,
-        "15025": List[TypeAirPurifier],
-        "15015": List[TypeBlind],
+        "3": DeviceInfoResponse,
+        "15025": List[AirPurifierResponse],
+        "15015": List[TypeBlindResponse],
     },
 )


### PR DESCRIPTION
Add type `TypedDict` for `ApiResource`, which combines previously added TypedDicts.

Following this PR, we will refactor and start using `pydantic`.