### PR TITLE
Add pydantic to requirements

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,7 @@ disallow_untyped_defs = true
 no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
+plugins = pydantic.mypy
 
 [mypy-pytradfri.*]
 check_untyped_defs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiocoap==0.4.3
 DTLSSocket==0.1.12
-
+pydantic==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ GITHUB_URL = "https://github.com/home-assistant-libs/pytradfri"
 DOWNLOAD_URL = f"{GITHUB_URL}/archive/{VERSION}.zip"
 
 EXTRAS_REQUIRE = {"async": ["aiocoap==0.4.3", "DTLSSocket==0.1.12"]}
-
+INSTALL_REQUIRES = ["pydantic"]
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 
 setup(
@@ -34,6 +34,7 @@ setup(
     keywords="ikea tradfri api iot light homeautomation",
     download_url=DOWNLOAD_URL,
     extras_require=EXTRAS_REQUIRE,
+    install_requires=INSTALL_REQUIRES,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR adds `pydantic` to the list of requirements so what we can add type hints using the [library](https://pydantic-docs.helpmanual.io/).

Also adding suggested plugin settings for `mypy`:
https://pydantic-docs.helpmanual.io/mypy_plugin/#enabling-the-plugin