### PR TITLE
Type aiocoap api

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -81,6 +81,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-pytradfri.api.aiocoap_api]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-pytradfri.device.controller]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -32,7 +32,7 @@ class UndefinedType(Enum):
     _singleton = 0
 
 
-_SINGELTON = UndefinedType._singleton  # pylint: disable=protected-access
+_SENTINEL = UndefinedType._singleton  # pylint: disable=protected-access
 
 
 class APIFactory:
@@ -46,7 +46,7 @@ class APIFactory:
         internal_create: UndefinedType | None = None,
     ):
         """Create object of class."""
-        if internal_create is not _SINGELTON:
+        if internal_create is not _SENTINEL:
             raise ValueError("Use APIFactory.init(…) to initialize APIFactory")
 
         self._psk = psk
@@ -62,7 +62,7 @@ class APIFactory:
         cls, host: str, psk_id: str = "pytradfri", psk: str | None = None
     ) -> "APIFactory":
         """Initialize an APIFactory."""
-        instance = cls(host, psk_id=psk_id, psk=psk, internal_create=_SINGELTON)
+        instance = cls(host, psk_id=psk_id, psk=psk, internal_create=_SENTINEL)
         if psk:
             await instance._update_credentials()
         return instance

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -31,8 +31,8 @@ class Command:
         self._err_callback = err_callback
         self._observe = observe
         self._observe_duration = observe_duration
-        self._raw_result: str | None = None
-        self._result: str | None = None
+        self._raw_result: dict | str | None = None
+        self._result: dict | str | None = None
 
     @property
     def method(self) -> str:
@@ -75,17 +75,17 @@ class Command:
         return self._observe_duration
 
     @property
-    def raw_result(self) -> str | None:
+    def raw_result(self) -> dict | str | None:
         """Return raw result."""
         return self._raw_result
 
     @property
-    def result(self) -> str | None:
+    def result(self) -> dict | str | None:
         """Return result."""
         return self._result
 
     @result.setter
-    def result(self, value: str) -> None:
+    def result(self, value: dict | str | None) -> None:
         """Return command result."""
         if self._process_result:
             self._result = self._process_result(value)

--- a/pytradfri/command.py
+++ b/pytradfri/command.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Callable, Optional
 
-TypeProcessResultCb = Optional[Callable[[Any], Optional[Any]]]
+TypeProcessResultCb = Optional[Callable[[Any], Any]]
 
 
 class Command:
@@ -31,8 +31,8 @@ class Command:
         self._err_callback = err_callback
         self._observe = observe
         self._observe_duration = observe_duration
-        self._raw_result: dict | str | None = None
-        self._result: dict | str | None = None
+        self._raw_result: list | dict | str | None = None
+        self._result: Any = None
 
     @property
     def method(self) -> str:
@@ -75,17 +75,17 @@ class Command:
         return self._observe_duration
 
     @property
-    def raw_result(self) -> dict | str | None:
+    def raw_result(self) -> list | dict | str | None:
         """Return raw result."""
         return self._raw_result
 
     @property
-    def result(self) -> dict | str | None:
+    def result(self) -> Any:
         """Return result."""
         return self._result
 
     @result.setter
-    def result(self, value: dict | str | None) -> None:
+    def result(self, value: list | dict | str | None) -> None:
         """Return command result."""
         if self._process_result:
             self._result = self._process_result(value)


### PR DESCRIPTION
- See https://github.com/home-assistant-libs/pytradfri/pull/388 for the previous attempt.
- I've corrected the type for the `Command.result` as that depends on the return value of the `process_result` callback.
- I'm planning to continue working on the command typing to make it more useful in follow up PRs.
