### PR TITLE
Add type hints for GatewayInfo

### DIFF
--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -373,7 +373,7 @@ class GatewayInfo:
 
     @property
     def time_source(self) -> int:
-        """Return homekit id."""
+        """Return time source."""
         return self.raw.time_source
 
     @property

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -320,7 +320,7 @@ class GatewayInfo:
 
     @property
     def firmware_version(self) -> str:
-        """NTP server in use."""
+        """Return gateway firmware version."""
         return self.raw.firmware_version
 
     @property

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
 
 from .command import Command
 from .const import (
+    ATTR_ALEXA_PAIR_STATUS,
     ATTR_AUTH,
+    ATTR_CERTIFICATE_PROV,
     ATTR_COMMISSIONING_MODE,
     ATTR_CURRENT_TIME_ISO8601,
     ATTR_CURRENT_TIME_UNIX,
@@ -16,9 +20,14 @@ from .const import (
     ATTR_GATEWAY_ID,
     ATTR_GATEWAY_INFO,
     ATTR_GATEWAY_REBOOT,
+    ATTR_GATEWAY_TIME_SOURCE,
+    ATTR_GATEWAY_UPDATE_PROGRESS,
+    ATTR_GOOGLE_HOME_PAIR_STATUS,
     ATTR_HOMEKIT_ID,
     ATTR_IDENTITY,
     ATTR_NTP,
+    ATTR_OTA_TYPE,
+    ATTR_OTA_UPDATE_STATE,
     ATTR_PSK,
     ROOT_DEVICES,
     ROOT_GATEWAY,
@@ -31,6 +40,26 @@ from .group import Group
 from .mood import Mood
 from .resource import TypeRaw
 from .smart_task import SmartTask
+
+
+class GatewayInfoResponse(BaseModel):
+    """Represent API response for the gateway."""
+
+    certificate_provisioned: int = Field(alias=ATTR_CERTIFICATE_PROV)
+    current_time: Optional[int] = Field(alias=ATTR_CURRENT_TIME_UNIX)
+    current_time_iso8601: str = Field(alias=ATTR_CURRENT_TIME_ISO8601)
+    commissioning_mode: int = Field(alias=ATTR_COMMISSIONING_MODE)
+    firmware_version: str = Field(alias=ATTR_FIRMWARE_VERSION)
+    first_setup: Optional[int] = Field(alias=ATTR_FIRST_SETUP)
+    homekit_id: str = Field(alias=ATTR_HOMEKIT_ID)
+    id: str = Field(alias=ATTR_GATEWAY_ID)
+    ntp_server: str = Field(alias=ATTR_NTP)
+    ota_type: int = Field(alias=ATTR_OTA_TYPE)
+    ota_update_state: int = Field(ATTR_OTA_UPDATE_STATE)
+    pair_status_alexa: int = Field(alias=ATTR_ALEXA_PAIR_STATUS)
+    pair_status_google_home: int = Field(ATTR_GOOGLE_HOME_PAIR_STATUS)
+    time_source: int = Field(alias=ATTR_GATEWAY_TIME_SOURCE)
+    update_progress: int = Field(alias=ATTR_GATEWAY_UPDATE_PROGRESS)
 
 
 class Gateway:
@@ -160,7 +189,7 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: dict[str, str | int]) -> GatewayInfo:
+        def process_result(result: dict[str, Any]) -> GatewayInfo:
             return GatewayInfo(result)
 
         return Command(
@@ -259,74 +288,119 @@ class Gateway:
 class GatewayInfo:
     """This class contains Gateway information."""
 
-    def __init__(self, raw):
+    _model_class: type[GatewayInfoResponse] = GatewayInfoResponse
+    raw: GatewayInfoResponse
+
+    def __init__(self, raw: TypeRaw):
         """Create object of class."""
-        self.raw = raw
+        self.raw = self._model_class(**raw)
 
     @property
-    def id(self):
-        """Return the gateway id."""
-        return self.raw.get(ATTR_GATEWAY_ID)
+    def certificate_provisioned(self) -> int:
+        """Return provisioning status of certificate."""
+        return self.raw.certificate_provisioned
 
     @property
-    def ntp_server(self):
-        """NTP server in use."""
-        return self.raw.get(ATTR_NTP)
-
-    @property
-    def firmware_version(self):
-        """NTP server in use."""
-        return self.raw.get(ATTR_FIRMWARE_VERSION)
-
-    @property
-    def current_time(self):
+    def current_time(self) -> datetime | None:
         """Return current time (normal timestamp)."""
-        if ATTR_CURRENT_TIME_UNIX not in self.raw:
-            return None
-        return datetime.utcfromtimestamp(self.raw[ATTR_CURRENT_TIME_UNIX])
+        if self.raw.current_time:
+            return datetime.utcfromtimestamp(self.raw.current_time)
+
+        return None
 
     @property
-    def current_time_iso8601(self):
+    def commissioning_mode(self) -> int:
+        """Return comissioning mode."""
+        return self.raw.commissioning_mode
+
+    @property
+    def current_time_iso8601(self) -> str:
         """Return current time in iso8601 format."""
-        return self.raw.get(ATTR_CURRENT_TIME_ISO8601)
+        return self.raw.current_time_iso8601
 
     @property
-    def first_setup(self):
+    def firmware_version(self) -> str:
+        """NTP server in use."""
+        return self.raw.firmware_version
+
+    @property
+    def first_setup(self) -> datetime | None:
         """Return the time when gateway was first set up."""
-        if ATTR_FIRST_SETUP not in self.raw:
-            return None
-        return datetime.utcfromtimestamp(self.raw[ATTR_FIRST_SETUP])
+        if self.raw.first_setup:
+            return datetime.utcfromtimestamp(self.raw.first_setup)
+
+        return None
 
     @property
-    def homekit_id(self):
+    def homekit_id(self) -> str:
         """Return homekit id."""
-        return self.raw.get(ATTR_HOMEKIT_ID)
+        return self.raw.homekit_id
 
     @property
-    def path(self):
+    def id(self) -> str:
+        """Return the gateway id."""
+        return self.raw.id
+
+    @property
+    def ntp_server(self) -> str:
+        """NTP server in use."""
+        return self.raw.ntp_server
+
+    @property
+    def ota_type(self) -> int:
+        """Return OTA type."""
+        return self.raw.ota_type
+
+    @property
+    def ota_update_state(self) -> int:
+        """Return OTA update state."""
+        return self.raw.ota_update_state
+
+    @property
+    def pair_status_google_home(self) -> int:
+        """Return pairing status Google Home."""
+        return self.raw.pair_status_google_home
+
+    @property
+    def pair_status_alexa(self) -> int:
+        """Return pairing status Amazon Alexa."""
+        return self.raw.pair_status_alexa
+
+    @property
+    def path(self) -> list[str]:
         """Return path."""
         return [ROOT_GATEWAY, ATTR_GATEWAY_INFO]
 
-    def set_values(self, values):
+    @property
+    def time_source(self) -> int:
+        """Return homekit id."""
+        return self.raw.time_source
+
+    @property
+    def update_progress(self) -> int:
+        """Return update status."""
+        return self.raw.update_progress
+
+    def set_values(self, values: dict[str, Any]) -> Command:
         """Help set values for mood.
 
         Returns a Command.
         """
         return Command("put", self.path, values)
 
-    def update(self):
+    def update(self) -> Command:
         """
         Update the info.
 
         Returns a Command.
         """
 
-        def process_result(result):
+        def process_result(result: GatewayInfoResponse) -> None:
             """Define callback to process result."""
             self.raw = result
 
         return Command("get", self.path, process_result=process_result)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return representation of class object."""
         return "<GatewayInfo>"

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -288,12 +288,11 @@ class Gateway:
 class GatewayInfo:
     """This class contains Gateway information."""
 
-    _model_class: type[GatewayInfoResponse] = GatewayInfoResponse
     raw: GatewayInfoResponse
 
-    def __init__(self, raw: TypeRaw):
+    def __init__(self, raw: TypeRaw) -> None:
         """Create object of class."""
-        self.raw = self._model_class(**raw)
+        self.raw = GatewayInfoResponse(**raw)
 
     @property
     def certificate_provisioned(self) -> int:
@@ -303,7 +302,7 @@ class GatewayInfo:
     @property
     def current_time(self) -> datetime | None:
         """Return current time (normal timestamp)."""
-        if self.raw.current_time:
+        if self.raw.current_time is not None:
             return datetime.utcfromtimestamp(self.raw.current_time)
 
         return None
@@ -326,7 +325,7 @@ class GatewayInfo:
     @property
     def first_setup(self) -> datetime | None:
         """Return the time when gateway was first set up."""
-        if self.raw.first_setup:
+        if self.raw.first_setup is not None:
             return datetime.utcfromtimestamp(self.raw.first_setup)
 
         return None
@@ -395,9 +394,9 @@ class GatewayInfo:
         Returns a Command.
         """
 
-        def process_result(result: GatewayInfoResponse) -> None:
+        def process_result(result: TypeRaw) -> None:
             """Define callback to process result."""
-            self.raw = result
+            self.raw = GatewayInfoResponse(**result)
 
         return Command("get", self.path, process_result=process_result)
 

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -189,7 +189,7 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: dict[str, Any]) -> GatewayInfo:
+        def process_result(result: TypeRaw) -> GatewayInfo:
             return GatewayInfo(result)
 
         return Command(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,4 +1,5 @@
 """Test Gateway."""
+from copy import deepcopy
 from datetime import datetime
 
 import pytest
@@ -8,33 +9,33 @@ from pytradfri.gateway import Gateway, GatewayInfo
 
 GATEWAY_INFO = {
     "9023": "xyz.pool.ntp.pool",
-    "9029": "1.2.42",
-    "9054": 0,
-    "9055": 0,
     "9059": 1509788799,
+    "9073": 0,  # Uknown
     "9060": "2017-11-04T09:46:39.046784Z",
-    "9061": 0,
-    "9062": 0,
-    "9066": 5,
-    "9069": 1509474847,
+    "9080": 0,  # Uknown
     "9071": 1,
-    "9072": 0,
-    "9073": 0,
-    "9074": 0,
-    "9075": 0,
-    "9076": 0,
-    "9077": 0,
-    "9078": 0,
-    "9079": 0,
-    "9080": 0,
-    "9081": "7e0000000000000a",
-    "9083": "123-45-67",
-    "9092": 0,
+    "9062": 0,  # Uknown
+    "9061": 0,
     "9093": 0,
-    "9106": 0,
+    "9029": "1.2.42",
+    "9081": "7e0000000000000a",
+    "9092": 0,
+    "9069": 1509474847,
+    "9082": True,  # Uknown
+    "9055": 0,
+    "9083": "123-45-67",
+    "9066": 5,
+    "9054": 0,
+    "9077": 0,  # Uknown
+    "9072": 0,  # Uknown
+    "9074": 0,  # Uknown
+    "9075": 0,  # Uknown
+    "9076": 0,  # Uknown
+    "9078": 0,  # Uknown
+    "9079": 0,  # Uknown
+    "9106": 0,  # Uknown
+    "9105": 0,  # Uknown
 }
-
-GATEWAY_INFO_EMPTY = {}
 
 
 @pytest.fixture
@@ -54,7 +55,6 @@ def test_get_device(gateway):
 def test_gateway_info():
     """Test retrival of gateway info."""
     gateway_info = GatewayInfo(GATEWAY_INFO)
-    gateway_info_empty = GatewayInfo(GATEWAY_INFO_EMPTY)
 
     assert gateway_info.id == "7e0000000000000a"
     assert gateway_info.ntp_server == "xyz.pool.ntp.pool"
@@ -64,6 +64,11 @@ def test_gateway_info():
     assert gateway_info.first_setup == datetime.utcfromtimestamp(1509474847)
     assert gateway_info.homekit_id == "123-45-67"
     assert gateway_info.path == ["15011", "15012"]
+
+    new_gateway = deepcopy(GATEWAY_INFO)
+    new_gateway["9059"] = None
+    new_gateway["9069"] = None
+    gateway_info_empty = GatewayInfo(new_gateway)
 
     assert gateway_info_empty.current_time is None
     assert gateway_info_empty.first_setup is None


### PR DESCRIPTION
This PR:
- Implements pydantic for the `GatewayInfo` response

We can't add the file to the strict typing list yet as we need to add type hints for `group.py` and `mood.py` first.