### PR TITLE
Make Command generic

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -194,7 +194,7 @@ class APIFactory:
             )
             return None
 
-        api_command.result = _process_output(res, parse_json)
+        api_command.process_result(_process_output(res, parse_json))
 
         return api_command.result
 
@@ -227,10 +227,10 @@ class APIFactory:
         # Note that this is necessary to start observing
         pr_req, pr_rsp = await self._get_response(msg, timeout)
 
-        api_command.result = _process_output(pr_rsp)
+        api_command.process_result(_process_output(pr_rsp))
 
         def success_callback(res: Message) -> None:
-            api_command.result = _process_output(res)
+            api_command.process_result(_process_output(res))
 
         def error_callback(exc: Exception) -> None:
             if isinstance(exc, LibraryShutdown):

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -95,7 +95,7 @@ class APIFactory:
             msg = f"Error executing request: {exc}"
             raise RequestError(msg) from None
 
-        api_command.result = _process_output(return_value, parse_json)
+        api_command.process_result(_process_output(return_value, parse_json))
         return api_command.result
 
     def request(self, api_commands, *, timeout=None):
@@ -166,7 +166,7 @@ class APIFactory:
             output += data
 
             if open_obj == 0:
-                api_command.result = _process_output(output)
+                api_command.process_result(_process_output(output))
                 output = ""
 
     def generate_psk(self, security_key):

--- a/pytradfri/device/air_purifier_control.py
+++ b/pytradfri/device/air_purifier_control.py
@@ -29,36 +29,38 @@ class AirPurifierControl(BaseController):
         """Return air purifier objects of the air purifier control."""
         return [AirPurifier(self._device, i) for i in range(len(self.raw))]
 
-    def turn_off(self, *, index: int = 0) -> Command:
+    def turn_off(self, *, index: int = 0) -> Command[None]:
         """Turn the device off."""
         return self.set_value({ATTR_AIR_PURIFIER_MODE: 0}, index=index)
 
-    def turn_on_auto_mode(self, *, index: int = 0) -> Command:
+    def turn_on_auto_mode(self, *, index: int = 0) -> Command[None]:
         """Turn on auto mode."""
         return self.set_value(
             {ATTR_AIR_PURIFIER_MODE: ATTR_AIR_PURIFIER_MODE_AUTO}, index=index
         )
 
-    def set_fan_speed(self, mode: int, *, index: int = 0) -> Command:
+    def set_fan_speed(self, mode: int, *, index: int = 0) -> Command[None]:
         """Set the fan speed of the purifier."""
         self._value_validate(mode, RANGE_AIR_PURIFIER, "Air Purifier mode")
         return self.set_value({ATTR_AIR_PURIFIER_MODE: mode}, index=index)
 
-    def set_controls_locked(self, locked: bool, *, index: int = 0) -> Command:
+    def set_controls_locked(self, locked: bool, *, index: int = 0) -> Command[None]:
         """Set physical controls locked of the air purifier."""
 
         return self.set_value(
             {ATTR_AIR_PURIFIER_CONTROLS_LOCKED: 1 if locked else 0}, index=index
         )
 
-    def set_leds_off(self, leds_off: bool, *, index: int = 0) -> Command:
+    def set_leds_off(self, leds_off: bool, *, index: int = 0) -> Command[None]:
         """Set led's off/on of the air purifier."""
 
         return self.set_value(
             {ATTR_AIR_PURIFIER_LEDS_OFF: 1 if leds_off else 0}, index=index
         )
 
-    def set_value(self, value: dict[str, bool | int], *, index: int = 0) -> Command:
+    def set_value(
+        self, value: dict[str, bool | int], *, index: int = 0
+    ) -> Command[None]:
         """Set values on air purifier control.
 
         Returns a Command.

--- a/pytradfri/device/blind_control.py
+++ b/pytradfri/device/blind_control.py
@@ -27,17 +27,17 @@ class BlindControl(BaseController):
         """Return blind objects of the blind control."""
         return [Blind(self._device, i) for i in range(len(self.raw))]
 
-    def trigger_blind(self) -> Command:
+    def trigger_blind(self) -> Command[None]:
         """Trigger the blind's movement."""
         return self.set_value({ATTR_BLIND_TRIGGER: True})
 
-    def set_state(self, state: int) -> Command:
+    def set_state(self, state: int) -> Command[None]:
         """Set state of a blind."""
         self._value_validate(state, RANGE_BLIND, "Blind position")
 
         return self.set_value({ATTR_BLIND_CURRENT_POSITION: state})
 
-    def set_value(self, value: dict[str, bool | int]) -> Command:
+    def set_value(self, value: dict[str, bool | int]) -> Command[None]:
         """Set values on blind control.
 
         Returns a Command.

--- a/pytradfri/device/light_control.py
+++ b/pytradfri/device/light_control.py
@@ -86,13 +86,13 @@ class LightControl(BaseController):
         """Return light objects of the light control."""
         return [Light(self._device, i) for i in range(len(self.raw))]
 
-    def set_state(self, state: bool, *, index: int = 0) -> Command:
+    def set_state(self, state: bool, *, index: int = 0) -> Command[None]:
         """Set state of a light."""
         return self.set_values({ATTR_DEVICE_STATE: int(state)}, index=index)
 
     def set_dimmer(
         self, dimmer: int, *, index: int = 0, transition_time: int | None = None
-    ) -> Command:
+    ) -> Command[None]:
         """Set dimmer value of a light.
 
         transition_time: Integer representing tenth of a second (default None)
@@ -108,7 +108,7 @@ class LightControl(BaseController):
 
     def set_color_temp(
         self, color_temp: int, *, index: int = 0, transition_time: int | None = None
-    ) -> Command:
+    ) -> Command[None]:
         """Set color temp a light."""
         self._value_validate(color_temp, RANGE_MIREDS, "Color temperature")
 
@@ -121,7 +121,7 @@ class LightControl(BaseController):
 
     def set_hex_color(
         self, color: str, *, index: int = 0, transition_time: int | None = None
-    ) -> Command:
+    ) -> Command[None]:
         """Set hex color of the light."""
         values: dict[str, str | int] = {
             ATTR_LIGHT_COLOR_HEX: color,
@@ -139,7 +139,7 @@ class LightControl(BaseController):
         *,
         index: int = 0,
         transition_time: int | None = None,
-    ) -> Command:
+    ) -> Command[None]:
         """Set xy color of the light."""
         self._value_validate(color_x, RANGE_X, "X color")
         self._value_validate(color_y, RANGE_Y, "Y color")
@@ -162,7 +162,7 @@ class LightControl(BaseController):
         *,
         index: int = 0,
         transition_time: int | None = None,
-    ) -> Command:
+    ) -> Command[None]:
         """Set HSB color settings of the light."""
         self._value_validate(hue, RANGE_HUE, "Hue")
         self._value_validate(saturation, RANGE_SATURATION, "Saturation")
@@ -183,7 +183,7 @@ class LightControl(BaseController):
 
     def set_predefined_color(
         self, colorname: str, *, index: int = 0, transition_time: int | None = None
-    ) -> Command:
+    ) -> Command[None]:
         """Set predefined color."""
         try:
             color = COLORS[colorname.lower().replace(" ", "_")]
@@ -193,7 +193,9 @@ class LightControl(BaseController):
         except KeyError:
             raise ColorError(f"Invalid color specified: {colorname}") from KeyError
 
-    def set_values(self, values: Mapping[str, str | int], *, index: int = 0) -> Command:
+    def set_values(
+        self, values: Mapping[str, str | int], *, index: int = 0
+    ) -> Command[None]:
         """Set values on light control.
 
         Returns a Command.

--- a/pytradfri/device/socket_control.py
+++ b/pytradfri/device/socket_control.py
@@ -22,11 +22,11 @@ class SocketControl(BaseController):
         """Return socket objects of the socket control."""
         return [Socket(self._device, i) for i in range(len(self.raw))]
 
-    def set_state(self, state: bool, *, index: int = 0) -> Command:
+    def set_state(self, state: bool, *, index: int = 0) -> Command[None]:
         """Set state of a socket."""
         return self.set_values({ATTR_DEVICE_STATE: int(state)}, index=index)
 
-    def set_values(self, values: dict[str, int], *, index: int = 0) -> Command:
+    def set_values(self, values: dict[str, int], *, index: int = 0) -> Command[None]:
         """Set values on socket control.
 
         Returns a Command.

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -66,7 +66,7 @@ class Gateway:
     """This class connects to the IKEA Tradfri Gateway."""
 
     @classmethod
-    def generate_psk(cls, identity: str) -> Command:
+    def generate_psk(cls, identity: str) -> Command[str]:
         """Generate the PRE_SHARED_KEY from the gateway.
 
         Returns a Command.
@@ -83,7 +83,7 @@ class Gateway:
         )
 
     @classmethod
-    def get_endpoints(cls) -> Command:
+    def get_endpoints(cls) -> Command[list[str]]:
         """
         Return all available endpoints on the gateway.
 
@@ -120,20 +120,20 @@ class Gateway:
             process_result=process_result,
         )
 
-    def get_devices(self) -> Command:
+    def get_devices(self) -> Command[list[Command[Device]]]:
         """
         Return the devices linked to the gateway.
 
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command]:
+        def process_result(result: list[str]) -> list[Command[Device]]:
             return [self.get_device(dev) for dev in result]
 
         return Command("get", [ROOT_DEVICES], process_result=process_result)
 
     @classmethod
-    def get_device(cls, device_id: str) -> Command:
+    def get_device(cls, device_id: str) -> Command[Device]:
         """
         Return specified device.
 
@@ -145,19 +145,19 @@ class Gateway:
 
         return Command("get", [ROOT_DEVICES, device_id], process_result=process_result)
 
-    def get_groups(self) -> Command:
+    def get_groups(self) -> Command[list[Command[Group]]]:
         """
         Return the groups linked to the gateway.
 
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command]:
+        def process_result(result: list[str]) -> list[Command[Group]]:
             return [self.get_group(group) for group in result]
 
         return Command("get", [ROOT_GROUPS], process_result=process_result)
 
-    def get_group(self, group_id: str) -> Command:
+    def get_group(self, group_id: str) -> Command[Group]:
         """
         Return specified group.
 
@@ -170,19 +170,19 @@ class Gateway:
         return Command("get", [ROOT_GROUPS, group_id], process_result=process_result)
 
     @classmethod
-    def add_group_member(cls, values: dict[str, Any]) -> Command:
+    def add_group_member(cls, values: dict[str, Any]) -> Command[None]:
         """Add a device to a group."""
 
         return Command("put", [ROOT_GROUPS, "add"], values)
 
     @classmethod
-    def remove_group_member(cls, values: dict[str, Any]) -> Command:
+    def remove_group_member(cls, values: dict[str, Any]) -> Command[None]:
         """Remove a device from a group."""
 
         return Command("put", [ROOT_GROUPS, "remove"], values)
 
     @classmethod
-    def get_gateway_info(cls) -> Command:
+    def get_gateway_info(cls) -> Command[GatewayInfo]:
         """
         Return the gateway info.
 
@@ -196,20 +196,20 @@ class Gateway:
             "get", [ROOT_GATEWAY, ATTR_GATEWAY_INFO], process_result=process_result
         )
 
-    def get_moods(self, group_id: str) -> Command:
+    def get_moods(self, group_id: str) -> Command[list[Command[Mood]]]:
         """
         Return moods available in given group.
 
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command]:
+        def process_result(result: list[str]) -> list[Command[Mood]]:
             return [self.get_mood(mood, mood_parent=group_id) for mood in result]
 
         return Command("get", [ROOT_MOODS, group_id], process_result=process_result)
 
     @classmethod
-    def get_mood(cls, mood_id: str, *, mood_parent: str) -> Command:
+    def get_mood(cls, mood_id: str, *, mood_parent: str) -> Command[Mood]:
         """
         Return a mood.
 
@@ -226,19 +226,19 @@ class Gateway:
             process_result=process_result,
         )
 
-    def get_smart_tasks(self) -> Command:
+    def get_smart_tasks(self) -> Command[list[Command[SmartTask]]]:
         """
         Return the transitions linked to the gateway.
 
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command]:
+        def process_result(result: list[str]) -> list[Command[SmartTask]]:
             return [self.get_smart_task(task) for task in result]
 
         return Command("get", [ROOT_SMART_TASKS], process_result=process_result)
 
-    def get_smart_task(self, task_id: str) -> Command:
+    def get_smart_task(self, task_id: str) -> Command[SmartTask]:
         """
         Return specified transition.
 
@@ -253,7 +253,7 @@ class Gateway:
         )
 
     @classmethod
-    def reboot(cls) -> Command:
+    def reboot(cls) -> Command[None]:
         """Reboot the Gateway.
 
         Returns a Command.
@@ -262,7 +262,7 @@ class Gateway:
         return Command("post", [ROOT_GATEWAY, ATTR_GATEWAY_REBOOT])
 
     @classmethod
-    def set_commissioning_timeout(cls, timeout: int) -> Command:
+    def set_commissioning_timeout(cls, timeout: int) -> Command[None]:
         """Put the gateway in pairing state.
 
         The pairing state is when the gateway accepts pairings from
@@ -275,7 +275,7 @@ class Gateway:
         )
 
     @classmethod
-    def factory_reset(cls) -> Command:
+    def factory_reset(cls) -> Command[None]:
         """Reset Gateway to factory defaults.
 
         WARNING: All data in Gateway is lost (pairing, groups, etc)

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -380,14 +380,14 @@ class GatewayInfo:
         """Return update status."""
         return self.raw.update_progress
 
-    def set_values(self, values: dict[str, Any]) -> Command:
+    def set_values(self, values: dict[str, Any]) -> Command[None]:
         """Help set values for mood.
 
         Returns a Command.
         """
         return Command("put", self.path, values)
 
-    def update(self) -> Command:
+    def update(self) -> Command[None]:
         """
         Update the info.
 

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .command import Command, TypeProcessResultCb
+from .command import Command
 from .const import ATTR_CREATED_AT, ATTR_ID, ATTR_NAME, ATTR_OTA_UPDATE_STATE
 
 # type alias
@@ -73,10 +73,10 @@ class ApiResource:
 
     def observe(
         self,
-        callback: TypeProcessResultCb,
+        callback: Callable[[ApiResource], None],
         err_callback: Callable[[Exception], None] | None,
         duration: int = 60,
-    ) -> Command:
+    ) -> Command[None]:
         """Observe resource and call callback when updated."""
 
         def observe_callback(value: TypeRaw) -> None:
@@ -100,11 +100,11 @@ class ApiResource:
             observe_duration=duration,
         )
 
-    def set_name(self, name: str) -> Command:
+    def set_name(self, name: str) -> Command[None]:
         """Set group name."""
         return self.set_values({ATTR_NAME: name})
 
-    def set_values(self, values: Any) -> Command:
+    def set_values(self, values: Any) -> Command[None]:
         """Help to set values for group.
 
         Helper to set values for group.
@@ -112,7 +112,7 @@ class ApiResource:
         """
         return Command("put", self.path, values)
 
-    def update(self) -> Command:
+    def update(self) -> Command[None]:
         """
         Update the group.
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -7,9 +7,6 @@ from pytradfri.command import Command
 def test_property_access():
     """Test property access in Command."""
 
-    def pr():
-        pass
-
     def ec():
         pass
 
@@ -20,7 +17,6 @@ def test_property_access():
         parse_json=True,
         observe=False,
         observe_duration=0,
-        process_result=pr,
         err_callback=ec,
     )
 
@@ -29,7 +25,6 @@ def test_property_access():
     assert command.parse_json is True
     assert command.observe is False
     assert command.observe_duration == 0
-    assert command.process_result == pr
     assert command.err_callback == ec
 
 
@@ -43,7 +38,7 @@ def test_result():
     assert command.result is None
     assert command.raw_result is None
 
-    command.result = 0
+    command.process_result(0)
     assert command.result == 1
     assert command.raw_result == 0
 


### PR DESCRIPTION
By making the `Command` class a generic type we can increase the information of the api method signatures and command return types.

Note that this is technically a breaking change as I've removed the setter functionality of the `Command.result` attribute. It was making the typing confusing in the api modules, so I wanted to remove this and use a regular method call instead to process the result. In practice this should not be a breaking change since it's normally only the internal api methods that process command results.

I'll follow up with more changes in the api module to take advantage of the generic command type.