### PR TITLE
Fix some typing issues

### DIFF
--- a/pytradfri/device/__init__.py
+++ b/pytradfri/device/__init__.py
@@ -71,14 +71,14 @@ class Device(ApiResource):
     raw: DeviceResponse
 
     @property
-    def application_type(self) -> int | None:
+    def application_type(self) -> int:
         """Return application type."""
         return self.raw.application_type
 
     @property
-    def path(self):
+    def path(self) -> list[str]:
         """Return path."""
-        return [ROOT_DEVICES, self.id]
+        return [ROOT_DEVICES, str(self.id)]
 
     @property
     def device_info(self) -> "DeviceInfo":
@@ -90,7 +90,7 @@ class Device(ApiResource):
         """Return timestamp when last seen."""
         last_seen = self.raw.last_seen
 
-        if last_seen:
+        if last_seen is not None:
             return datetime.utcfromtimestamp(last_seen)
 
         return None
@@ -110,7 +110,6 @@ class Device(ApiResource):
         """Return light_control."""
         if self.has_light_control:
             return LightControl(self)
-
         return None
 
     @property

--- a/pytradfri/device/light.py
+++ b/pytradfri/device/light.py
@@ -48,7 +48,7 @@ class Light:
     pdf
     """
 
-    def __init__(self, device: Device, index: int):
+    def __init__(self, device: Device, index: int) -> None:
         """Create object of class."""
         self.device = device
         self.index = index

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -196,7 +196,7 @@ class Gateway:
             "get", [ROOT_GATEWAY, ATTR_GATEWAY_INFO], process_result=process_result
         )
 
-    def get_moods(self, group_id: str) -> Command[list[Command[Mood]]]:
+    def get_moods(self, group_id: int) -> Command[list[Command[Mood]]]:
         """
         Return moods available in given group.
 
@@ -206,10 +206,12 @@ class Gateway:
         def process_result(result: list[str]) -> list[Command[Mood]]:
             return [self.get_mood(mood, mood_parent=group_id) for mood in result]
 
-        return Command("get", [ROOT_MOODS, group_id], process_result=process_result)
+        return Command(
+            "get", [ROOT_MOODS, str(group_id)], process_result=process_result
+        )
 
     @classmethod
-    def get_mood(cls, mood_id: str, *, mood_parent: str) -> Command[Mood]:
+    def get_mood(cls, mood_id: str, *, mood_parent: int) -> Command[Mood]:
         """
         Return a mood.
 
@@ -221,7 +223,7 @@ class Gateway:
 
         return Command(
             "get",
-            [ROOT_MOODS, mood_parent, mood_id],
+            [ROOT_MOODS, str(mood_parent), mood_id],
             mood_parent,
             process_result=process_result,
         )

--- a/pytradfri/group.py
+++ b/pytradfri/group.py
@@ -38,7 +38,7 @@ class Group(ApiResource):
     @property
     def path(self):
         """Path."""
-        return [ROOT_GROUPS, self.id]
+        return [ROOT_GROUPS, str(self.id)]
 
     @property
     def state(self):

--- a/pytradfri/mood.py
+++ b/pytradfri/mood.py
@@ -8,7 +8,7 @@ from .resource import ApiResource, TypeRaw
 class Mood(ApiResource):
     """Mood."""
 
-    def __init__(self, raw: TypeRaw, parent: str) -> None:
+    def __init__(self, raw: TypeRaw, parent: int) -> None:
         """Create object of class."""
         super().__init__(raw)
         self._parent = parent

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -37,7 +37,7 @@ class ApiResource:
             self.raw = raw
 
     @property
-    def id(self) -> int | None:
+    def id(self) -> int:
         """Id."""
         if self._model_class:
             resource_id = self.raw.id  # type: ignore[union-attr]
@@ -46,7 +46,7 @@ class ApiResource:
         return resource_id
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Name."""
         if self._model_class:
             name = self.raw.name  # type: ignore[union-attr]

--- a/pytradfri/smart_task.py
+++ b/pytradfri/smart_task.py
@@ -57,7 +57,7 @@ class SmartTask(ApiResource):
     @property
     def path(self):
         """Return gateway path."""
-        return [ROOT_SMART_TASKS, self.id]
+        return [ROOT_SMART_TASKS, str(self.id)]
 
     @property
     def state(self):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -365,7 +365,7 @@ def test_device_properties(device):
     assert device.id == 65539
     assert device.created_at == datetime.utcfromtimestamp(1509923713)
     assert device.reachable
-    assert device.path == [ROOT_DEVICES, 65539]
+    assert device.path == [ROOT_DEVICES, "65539"]
 
 
 def test_device_info_properties(device):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -66,4 +66,4 @@ def test_setters(group):
 def test_moods(group):
     """Test moods."""
     cmd = group.moods()
-    assert cmd.path == [ROOT_MOODS, group.id]
+    assert cmd.path == [ROOT_MOODS, str(group.id)]

--- a/tests/test_smart_task.py
+++ b/tests/test_smart_task.py
@@ -106,7 +106,7 @@ def test_smart_task_set_start_action_dimmer():
     )
 
     assert cmd.method == "put"
-    assert cmd.path == ["15010", 317094]
+    assert cmd.path == ["15010", "317094"]
     assert cmd.data == {
         "9042": {
             "15013": [


### PR DESCRIPTION
- We only use the `Command.path` property to construct the `Command.url` and there we copy all items to string. But I think it's more consistent if we make sure that the `path` items are strings from the beginning.

fixes #449 