### PR TITLE
Minor type hint fixes

### DIFF
--- a/pytradfri/device/__init__.py
+++ b/pytradfri/device/__init__.py
@@ -26,8 +26,10 @@ from ..const import (
 )
 from ..device.light import LightResponse
 from ..resource import ApiResource, ApiResourceResponse
-from .air_purifier_control import AirPurifierControl, AirPurifierResponse
-from .blind_control import BlindControl, BlindResponse
+from .air_purifier import AirPurifierResponse
+from .air_purifier_control import AirPurifierControl
+from .blind import BlindResponse
+from .blind_control import BlindControl
 from .light_control import LightControl
 from .signal_repeater import SignalRepeaterResponse
 from .signal_repeater_control import SignalRepeaterControl


### PR DESCRIPTION
Fixes:
```
pytradfri/device/__init__.py:29: error: Module "pytradfri.device.air_purifier_control" does not explicitly export attribute "AirPurifierResponse"; implicit reexport disabled  [attr-defined]
pytradfri/device/__init__.py:30: error: Module "pytradfri.device.blind_control" does not explicitly export attribute "BlindResponse"; implicit reexport disabled  [attr-defined]
```
