### PR TITLE
Add gateway.py to mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -289,3 +289,14 @@ disallow_untyped_defs = true
 no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
+
+[mypy-pytradfri.gateway]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true


### PR DESCRIPTION
This PR finalises adding type hints to gateway.py. We couldn't add the file to mypy.ini in a previous PR as some imported modules weren't typed yet.