### PR TITLE
Add checks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: isort
         name: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
       - id: requirements-txt-fixer
       - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,15 @@ repos:
     hooks:
       - id: isort
         name: isort
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: requirements-txt-fixer
+      - id: check-json
+        exclude: (.vscode|.devcontainer)
+      - id: no-commit-to-branch
+        args:
+          - --branch=master
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
I accidentally committed and pushed the version bump to master (have reverted that). Don't want to do the same mistake again so I'm adding a rule to pre-commit.

On a side note, I use Azure's git repos for work and we can set a rule preventing commits without PRs. Can that be on Github too? I'm not an admin of this repo so I can't check.