### PR TITLE
Clarify meaning of filter_status property

### DIFF
--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -93,7 +93,7 @@ class AirPurifier:
 
     @property
     def filter_status(self) -> bool:
-        """Return true if filter needs to be replaced."""
+        """Return True if filter needs to be replaced."""
         return bool(self.raw.filter_status)
 
     @property

--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -92,9 +92,9 @@ class AirPurifier:
         return self.raw.filter_runtime
 
     @property
-    def filter_status(self) -> int:
-        """Return filter status."""
-        return self.raw.filter_status
+    def filter_status(self) -> bool:
+        """Return true if filter needs to be replaced."""
+        return bool(self.raw.filter_status)
 
     @property
     def is_auto_mode(self) -> bool:

--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -93,7 +93,11 @@ class AirPurifier:
 
     @property
     def filter_status(self) -> bool:
-        """Return True if filter needs to be replaced."""
+        """
+        Return True if filter needs to be replaced.
+
+        This property is true when filter_lifetime_remaining is less than zero.
+        """
         return bool(self.raw.filter_status)
 
     @property

--- a/tests/test_air_purifiers.py
+++ b/tests/test_air_purifiers.py
@@ -82,7 +82,7 @@ def test_filter_status(device):
     """Test filter status."""
 
     air_purifier = device.air_purifier_control.air_purifiers[0]
-    assert air_purifier.filter_status == 0
+    assert air_purifier.filter_status is False
 
 
 def test_filter_lifetime_remaining(device):


### PR DESCRIPTION
Six months have passed since I installed the filter on the device and the `filter_lifetime_remaining` property now reports a negative value of 31 minutes. In the app, there is an indicator that the filter expires today.

I therefore propose this clarification to the `filter_status` property.

```
DeviceResponse(
  id=65554,
  name='Luftrenare',
  created_at=1634661517,
  ota_update_state=0,
  air_purifier_control=[
    AirPurifierResponse(
      id=0,
      air_quality=11,
      controls_locked=0,
      fan_speed=10,
      filter_lifetime_remaining=-31,
      filter_lifetime_total=259200,
      filter_runtime=259231,
      filter_status=1,
      leds_off=0,
      mode=1,
      motor_runtime_total=259231
   )
],

application_type=10,
blind_control=None,
device_info=DeviceInfoResponse(manufacturer='IKEA of Sweden', model_number='STARKVIND Air purifier', serial='',firmware_version='1.0.033', power_source=1, battery_level=None),
last_seen=1650565905,
light_control=None,
reachable=1,
signal_repeater_control=None,
socket_control=None
)
```