### PR TITLE
Change repo to Github from Gitlab for pre-commit flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
           - --safe
           - --quiet
         files: ^(pytradfri|examples|tests)/.+\.py$
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
I was planning on creating a workflow using Renovate but it seemed that required creating an app, which seemed a cumbersome way to go.

Noticed we were using a mirror in the pre-commit config so I figured we could try switching to the official repo to see if that, alhtough it wouldn't make sense, helps in the incorrect version update.