### PR TITLE
Allow pydantic during pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ ignore = [
 # Use a conservative default here; 2 should speed up most setups and not hurt
 # any too bad. Override on command line as appropriate.
 jobs = 2
+extension-pkg-whitelist = "pydantic"
 init-hook='from pylint.config.find_default_config_files import find_default_config_files; from pathlib import Path; import sys; sys.path.append(str(Path(Path(list(find_default_config_files())[0]).parent, "pylint/plugins")))'
 load-plugins = [
     "pylint.extensions.code_style",


### PR DESCRIPTION
- This avoids false positive no name error during pylint.