### PR TITLE
Rework light supported features

### DIFF
--- a/examples/example_color.py
+++ b/examples/example_color.py
@@ -122,7 +122,7 @@ async def run():
     light = None
     # Find a bulb that can set color
     for dev in lights:
-        if dev.light_control.can_set_color:
+        if dev.light_control.lights[0].supports_hsb_xy_color:
             light = dev
             break
 

--- a/pytradfri/color.py
+++ b/pytradfri/color.py
@@ -46,16 +46,16 @@ def supported_features(data: LightResponse) -> int:
     """Return supported features."""
     supported_color_features = 0
 
-    if data.dimmer:
+    if data.dimmer is not None:
         supported_color_features = supported_color_features + SUPPORT_BRIGHTNESS
 
     if data.color_hex:
         supported_color_features = supported_color_features + SUPPORT_HEX_COLOR
 
-    if data.color_mireds:
+    if data.color_mireds is not None:
         supported_color_features = supported_color_features + SUPPORT_COLOR_TEMP
 
-    if data.color_xy_x and data.color_xy_y:
+    if None not in (data.color_xy_x, data.color_xy_y):
         supported_color_features = supported_color_features + SUPPORT_XY_COLOR
 
     if (
@@ -64,6 +64,7 @@ def supported_features(data: LightResponse) -> int:
         and data.color_xy_y is not None
         and data.color_saturation is not None
         and data.color_hue is not None
+        and data.dimmer is not None
     ):
         supported_color_features = supported_color_features + SUPPORT_RGB_COLOR
 

--- a/pytradfri/device/light.py
+++ b/pytradfri/device/light.py
@@ -18,6 +18,7 @@ from ..const import (
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP,
     SUPPORT_HEX_COLOR,
+    SUPPORT_RGB_COLOR,
     SUPPORT_XY_COLOR,
 )
 from ..resource import BaseResponse
@@ -36,7 +37,7 @@ class LightResponse(BaseResponse):
     color_xy_y: Optional[int] = Field(alias=ATTR_LIGHT_COLOR_Y)
     color_hue: Optional[int] = Field(alias=ATTR_LIGHT_COLOR_HUE)
     color_saturation: Optional[int] = Field(alias=ATTR_LIGHT_COLOR_SATURATION)
-    dimmer: int = Field(alias=ATTR_LIGHT_DIMMER)
+    dimmer: Optional[int] = Field(alias=ATTR_LIGHT_DIMMER)
     state: int = Field(alias=ATTR_DEVICE_STATE)
 
 
@@ -58,6 +59,31 @@ class Light:
         return supported_features(self.raw)
 
     @property
+    def supports_dimmer(self) -> bool:
+        """Return True if light supports dimmer."""
+        return bool(self.supported_features & SUPPORT_BRIGHTNESS)
+
+    @property
+    def supports_color_temp(self) -> bool:
+        """Return True if light supports color temperature."""
+        return bool(self.supported_features & SUPPORT_COLOR_TEMP)
+
+    @property
+    def supports_hex_color(self) -> bool:
+        """Return True if light supports hex color."""
+        return bool(self.supported_features & SUPPORT_HEX_COLOR)
+
+    @property
+    def supports_xy_color(self) -> bool:
+        """Return True if light supports xy color."""
+        return bool(self.supported_features & SUPPORT_XY_COLOR)
+
+    @property
+    def supports_hsb_xy_color(self) -> bool:
+        """Return True if light supports hsb xy color."""
+        return bool(self.supported_features & SUPPORT_RGB_COLOR)
+
+    @property
     def state(self) -> bool:
         """Return device state."""
         return self.raw.state == 1
@@ -65,32 +91,22 @@ class Light:
     @property
     def dimmer(self) -> int | None:
         """Return dimmer if present."""
-        if self.supported_features & SUPPORT_BRIGHTNESS:
-            return self.raw.dimmer
-        return None
+        return self.raw.dimmer
 
     @property
     def color_temp(self) -> int | None:
         """Return color temperature."""
-        if self.supported_features & SUPPORT_COLOR_TEMP and self.raw.color_mireds:
-            return self.raw.color_mireds
-        return None
+        return self.raw.color_mireds
 
     @property
     def hex_color(self) -> str | None:
         """Return hex color."""
-        if self.supported_features & SUPPORT_HEX_COLOR:
-            return self.raw.color_hex
-        return None
+        return self.raw.color_hex
 
     @property
     def xy_color(self) -> tuple[int, int] | None:
         """Return xy color."""
-        if (
-            self.supported_features & SUPPORT_XY_COLOR
-            and self.raw.color_xy_x is not None
-            and self.raw.color_xy_y is not None
-        ):
+        if self.raw.color_xy_x is not None and self.raw.color_xy_y is not None:
             return (self.raw.color_xy_x, self.raw.color_xy_y)
         return None
 

--- a/pytradfri/device/light_control.py
+++ b/pytradfri/device/light_control.py
@@ -40,23 +40,7 @@ class LightControl(BaseController):
         """Create object of class."""
         super().__init__(device)
 
-        self.can_set_dimmer: bool = False
-        self.can_set_temp: bool = False
-        self.can_set_xy: bool = False
-        self.can_set_color: bool = False
         self.can_combine_commands: bool = False
-
-        if ATTR_LIGHT_DIMMER in self.raw[0].dict():
-            self.can_set_dimmer = True
-
-        if ATTR_LIGHT_MIREDS in self.raw[0].dict():
-            self.can_set_temp = True
-
-        if ATTR_LIGHT_COLOR_X in self.raw[0].dict():
-            self.can_set_xy = True
-
-        if ATTR_LIGHT_COLOR_HUE in self.raw[0].dict():
-            self.can_set_color = True
 
         # Currently uncertain which bulbs are capable of setting
         # multiple values simultaneously. As of gateway firmware

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -24,6 +24,11 @@ def test_white_bulb():
 
     assert bulb.hex_color is None
     assert bulb.xy_color is None
+    assert bulb.supports_dimmer
+    assert not bulb.supports_color_temp
+    assert not bulb.supports_hex_color
+    assert not bulb.supports_xy_color
+    assert not bulb.supports_hsb_xy_color
 
 
 def test_spectrum_bulb():
@@ -33,6 +38,11 @@ def test_spectrum_bulb():
     assert bulb.hex_color == "0"
     assert bulb.xy_color == (31103, 27007)
     assert bulb.color_temp == 400
+    assert bulb.supports_dimmer
+    assert bulb.supports_color_temp
+    assert bulb.supports_hex_color
+    assert bulb.supports_xy_color
+    assert not bulb.supports_hsb_xy_color
 
 
 def test_spectrum_bulb_custom_color():
@@ -41,6 +51,11 @@ def test_spectrum_bulb_custom_color():
 
     assert bulb.hex_color == "0"
     assert bulb.xy_color == (32228, 27203)
+    assert bulb.supports_dimmer
+    assert bulb.supports_color_temp
+    assert bulb.supports_hex_color
+    assert bulb.supports_xy_color
+    assert not bulb.supports_hsb_xy_color
 
 
 def test_color_bulb():
@@ -48,7 +63,12 @@ def test_color_bulb():
     bulb = light(LIGHT_CWS)
 
     assert bulb.hex_color == "f1e0b5"
-    #  assert bulb.xy_color == (32768, 15729) # temporarily disable
+    assert bulb.xy_color == (30015, 26870)
+    assert bulb.supports_dimmer
+    assert not bulb.supports_color_temp
+    assert bulb.supports_hex_color
+    assert bulb.supports_xy_color
+    assert bulb.supports_hsb_xy_color
 
 
 def test_color_bulb_custom_color():
@@ -56,7 +76,12 @@ def test_color_bulb_custom_color():
     bulb = light(LIGHT_CWS_CUSTOM_COLOR)
 
     assert bulb.hex_color == "0"
-    #  assert bulb.xy_color == (23327, 33940) # temporarily disable
+    assert bulb.xy_color == (23327, 33940)
+    assert bulb.supports_dimmer
+    assert not bulb.supports_color_temp
+    assert bulb.supports_hex_color
+    assert bulb.supports_xy_color
+    assert bulb.supports_hsb_xy_color
 
 
 def test_setters():


### PR DESCRIPTION
- The "can_set_*" attributes on the light control instance were broken after the big refactor with Pydantic.
- Fix that by introducing a new set of properties on the Light class that returns the available features of the light.
- I think these properties belong on the Light class instead of LightControl as the LightResponse data is needed to check supported features and that data is available directly on the Light instance but only indirectly on the LigthControl instance. It doesn't matter for the LightControl instance what kind of lights it controls.