### PR TITLE
Add combine commands to light control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,5 +13,6 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise AssertionError
     raise NotImplementedError
+    if TYPE_CHECKING:
 omit =
     pytradfri/__main__.py


### PR DESCRIPTION
- Some light bulbs support receiving multiple light data items in the same command, eg dimmer and hsb color or dimmer and color temp.
- Add back a way for the library user to combine light control commands into one command with merged data.
- We removed the general way to merge commands previously as it is complicated to support the general case. There's also no known real use case for combining other commands than light control commands.
- We still have the attribute `LightControl.can_combine_commands` so it makes sense to have a method `LightControl.combine_commands`.