### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.0.0
         with:
-          python-version: 3.8
+          python-version: "3.9"
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit autoupdate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 show_error_codes = true
 follow_imports = silent
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ forced_separate = [
 combine_as_imports = true
 
 [tool.pylint.MASTER]
-py-version = "3.8"
+py-version = "3.9"
 ignore = [
 ]
 # Use a conservative default here; 2 should speed up most setups and not hurt

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*"])
 setup(
     name="pytradfri",
     packages=PACKAGES,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     version=VERSION,
     description="IKEA Trådfri/Tradfri API. Control and observe your "
     "lights from Python.",
@@ -41,7 +41,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Home Automation",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py38, py39, py310, lint, typing, coverage
+envlist = py39, py310, lint, typing, coverage
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38, lint, typing, coverage
-  3.9: py39
+  3.9: py39, lint, typing, coverage
   3.10: py310
 
 [testenv]


### PR DESCRIPTION
- I suggest we drop support for Python 3.8.
- Home Assistant only supports Python 3.9 and Python 3.10.
- aiocoap is thinking about dropping Python 3.8.
- It simplifies typing somewhat (will address in separate PR that solves pylint issues).