### PR TITLE
Bump aiocoap to 0.4.4 in setup.EXTRAS_REQUIRE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ VERSION = (PROJECT_DIR / "pytradfri" / "VERSION").read_text().strip()
 GITHUB_URL = "https://github.com/home-assistant-libs/pytradfri"
 DOWNLOAD_URL = f"{GITHUB_URL}/archive/{VERSION}.zip"
 
-EXTRAS_REQUIRE = {"async": ["aiocoap==0.4.3", "DTLSSocket==0.1.12"]}
+EXTRAS_REQUIRE = {"async": ["aiocoap==0.4.4", "DTLSSocket==0.1.12"]}
 INSTALL_REQUIRES = ["pydantic"]
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 


### PR DESCRIPTION
This is a follow-up to https://github.com/home-assistant-libs/pytradfri/pull/539#issuecomment-1229242499.