### PR TITLE
Add Python 3.11 to CI/CD pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3.3.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Home Automation",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py39, py310, lint, typing, coverage
+envlist = py39, py310, py311, lint, typing, coverage
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
   3.9: py39, lint, typing, coverage
   3.10: py310
+  3.11: py311
 
 [testenv]
 commands =


### PR DESCRIPTION
I read that support for Python 3.9 has been dropped in core so I guess we could drop it here too. Before doing that, I propose we add 3.11 to the pipeline run.