### PR TITLE
Fix overgeneral-exceptions error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,8 @@ expected-line-ending-format = "LF"
 
 [tool.pylint.EXCEPTIONS]
 overgeneral-exceptions = [
-  "BaseException",
-  "Exception",
+  "builtins.BaseException",
+  "builtins.Exception",
 ]
 
 [tool.pylint.TYPING]


### PR DESCRIPTION
Pylint flooded output with `pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.` before making this adjustment.