### PR TITLE
Use pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,4 +120,4 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-#ignore_errors = true
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ runtime-typing = false
 max-line-length-suggestions = 72
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 norecursedirs = [
   ".git",
   "testing_config",
@@ -119,4 +120,4 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-ignore_errors = true
+#ignore_errors = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,6 @@ pre-commit==3.0.4
 pylint==2.16.1
 pylint_strict_informational==0.1
 pytest==7.2.1
+pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-timeout==2.1.0

--- a/tests/api/test_aiocoap_api.py
+++ b/tests/api/test_aiocoap_api.py
@@ -1,28 +1,17 @@
-"""Test API utilities."""
-import asyncio
-import functools
+"""Test aiocoap API."""
+from typing import Any
+
+from aiocoap import Message
+import pytest
 
 from pytradfri.api.aiocoap_api import APIFactory
 from pytradfri.command import Command
 
 
-def async_test(func):
-    """Start test."""
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        """Wrap to start event loop."""
-        future = func(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
-
-    return wrapper
-
-
 class MockCode:
     """Mock Code."""
 
-    def is_successful(self):
+    def is_successful(self) -> bool:
         """Is successful."""
         return True
 
@@ -31,25 +20,25 @@ class MockResponse:
     """Mock response."""
 
     @property
-    def code(self):
+    def code(self) -> MockCode:
         """Return code."""
         return MockCode()
 
     @property
-    def payload(self):
+    def payload(self) -> bytes:
         """Return payload."""
-        return b"{}"
+        return b'{"one": 1}'
 
 
 class MockProtocol:
     """Mock Protocol."""
 
-    async def mock_response(self):
+    async def mock_response(self) -> Any:
         """Return protocol response."""
         return MockResponse()
 
     @property
-    def response(self):
+    def response(self) -> Any:
         """Return protocol response."""
         return self.mock_response()
 
@@ -57,39 +46,43 @@ class MockProtocol:
 class MockContext:
     """Mock a context."""
 
-    def request(self, arg):
+    def request(self, message: Message) -> MockProtocol:
         """Request a protocol."""
         return MockProtocol()
 
 
-async def mock_create_context():
+async def mock_create_context() -> MockContext:
     """Return a context."""
     return MockContext()
 
 
-@async_test
-async def test_request_returns_single(monkeypatch):
+def process_result(result: Any) -> Any:
+    """Process result."""
+    return result
+
+
+async def test_request_returns_single(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test return single object."""
     monkeypatch.setattr("aiocoap.Context.create_client_context", mock_create_context)
 
     api = (await APIFactory.init("127.0.0.1")).request
 
-    command = Command("", "")
+    command: Command[dict[str, int]] = Command("", [""], process_result=process_result)
 
     response = await api(command)
 
-    assert not isinstance(response, list)
+    assert response == {"one": 1}
 
 
-@async_test
-async def test_request_returns_list(monkeypatch):
+async def test_request_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test return of lists."""
     monkeypatch.setattr("aiocoap.Context.create_client_context", mock_create_context)
 
     api = (await APIFactory.init("127.0.0.1")).request
 
-    command = Command("", "")
+    command: Command[dict[str, int]] = Command("", [""], process_result=process_result)
 
     response = await api([command, command, command])
 
     assert isinstance(response, list)
+    assert response == [{"one": 1}, {"one": 1}, {"one": 1}]


### PR DESCRIPTION
- Use pytest-asyncio instead of custom code to test asyncio code.
- Clean up the aiocoap api tests.
- Solves this warning in CI:

```
  =============================== warnings summary ===============================
  tests/api/test_aiocoap_api.py::test_request_returns_single
    /home/runner/work/pytradfri/pytradfri/tests/api/test_aiocoap_api.py:16: DeprecationWarning: There is no current event loop
      loop = asyncio.get_event_loop()
```