### PR TITLE
Add quotes to Python version in mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ testpaths = [
 ]
 
 [tool.mypy]
-python_version = 3.10
+python_version = "3.10"
 show_error_codes = true
 follow_imports = "silent"
 ignore_missing_imports = true


### PR DESCRIPTION
Resolves this error `pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.4 or higher). You may need to put quotes around your Python version`