### PR TITLE
Add more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,9 +126,24 @@ ignore_errors = true
 target-version = "py310"
 
 select = [
+    "B007", # Loop control variable {name} not used within loop body
+    "B014", # Exception handler with duplicate exception
+    "C",  # complexity
     "F",  # pyflakes/autoflake
     "I",  # isort
+    "ICN001", # import concentions; {name} should be imported as {asname}
+    "PGH004",  # Use specific rule codes when using noqa
+    "PLC0414", # Useless import alias. Import alias does not rename original package.
+    "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
+    "SIM117", # Merge with-statements that use the same scope
+    "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
+    "SIM201", # Use {left} != {right} instead of not {left} == {right}
+    "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
+    "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
+    "SIM401", # Use get from dict with default instead of an if block
+    "TRY004", # Prefer TypeError exception for invalid type
     "UP",  # pyupgrade
+    "W",  # pycodestyle
 ]
 
 [tool.ruff.isort]


### PR DESCRIPTION
Enabling a few more of the ruff rules I found in the `core` repo's `pyproject.toml`.