### PR TITLE
Add D-rule in ruff

### DIFF
--- a/examples/debug_info.py
+++ b/examples/debug_info.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This file generates debug information about your Tradfri network.
+"""Generates debug information about your Tradfri network.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/examples/debug_info.py
+++ b/examples/debug_info.py
@@ -24,7 +24,7 @@ import uuid
 folder = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.normpath(f"{folder}/.."))
 
-# pylint: disable=import-error, wrong-import-position, useless-suppression
+# pylint: disable=import-error, wrong-import-position, useless-suppression, not-an-iterable # noqa: E501
 
 from pytradfri import Gateway
 from pytradfri.api.libcoap_api import APIFactory

--- a/examples/example_air_purifier_async.py
+++ b/examples/example_air_purifier_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example of how the pytradfri-library can be used async.
+"""Example of how the pytradfri-library can be used async.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example of how the pytradfri-library can be used async.
+"""Example of how the pytradfri-library can be used async.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/examples/example_cover_async.py
+++ b/examples/example_cover_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example of how the pytradfri-library can be used async.
+"""Example of how the pytradfri-library can be used async.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/examples/example_socket_async.py
+++ b/examples/example_socket_async.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example of how the pytradfri-library can be used async.
+"""Example of how the pytradfri-library can be used async.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -23,7 +23,7 @@ import uuid
 folder = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.normpath(f"{folder}/.."))
 
-# pylint: disable=import-error, wrong-import-position, useless-suppression
+# pylint: disable=import-error, wrong-import-position, useless-suppression, not-an-iterable, unsubscriptable-object # noqa: E501
 
 from pytradfri import Gateway
 from pytradfri.api.libcoap_api import APIFactory, APIRequestProtocol

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example of how the pytradfri-library can be used.
+"""Example of how the pytradfri-library can be used.
 
 To run the script, do the following:
 $ pip3 install pytradfri

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ select = [
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
     "C",  # complexity
+    "D",  # docstrings
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
     "I",  # isort
@@ -145,6 +146,12 @@ select = [
     "TRY004", # Prefer TypeError exception for invalid type
     "UP",  # pyupgrade
     "W",  # pycodestyle
+]
+
+ignore = [
+    "D202",  # No blank lines allowed after function docstring
+    "D203",  # 1 blank line required before class docstring
+    "D213",  # Multi-line docstring summary should start at the second line
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ select = [
 ]
 
 ignore = [
-    "D202",  # No blank lines allowed after function docstring
     "D203",  # 1 blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
 ]

--- a/pytradfri/__main__.py
+++ b/pytradfri/__main__.py
@@ -17,7 +17,7 @@ from .gateway import Gateway
 
 CONFIG_FILE = "tradfri_standalone_psk.conf"
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, not-an-iterable, unsubscriptable-object
 
 
 if __name__ == "__main__":

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -42,13 +42,13 @@ class APIRequestProtocol(Protocol):
     async def __call__(
         self, api_commands: Command[T], timeout: float | None = None
     ) -> T:
-        """Define the signature of the request method."""
+        ...
 
     @overload
     async def __call__(
         self, api_commands: list[Command[T]], timeout: float | None = None
     ) -> list[T]:
-        """Define the signature of the request method."""
+        ...
 
     async def __call__(
         self, api_commands: Command[T] | list[Command[T]], timeout: float | None = None
@@ -215,13 +215,13 @@ class APIFactory:
     async def request(
         self, api_commands: Command[T], timeout: float | None = None
     ) -> T:
-        """Make a request."""
+        ...
 
     @overload
     async def request(
         self, api_commands: list[Command[T]], timeout: float | None = None
     ) -> list[T]:
-        """Make a request."""
+        ...
 
     async def request(
         self, api_commands: Command[T] | list[Command[T]], timeout: float | None = None

--- a/pytradfri/api/libcoap_api.py
+++ b/pytradfri/api/libcoap_api.py
@@ -22,13 +22,13 @@ class APIRequestProtocol(Protocol):
 
     @overload
     def __call__(self, api_commands: Command[T], timeout: int | None = None) -> T:
-        """Define the signature of the request method."""
+        ...
 
     @overload
     def __call__(
         self, api_commands: list[Command[T]], timeout: int | None = None
     ) -> list[T]:
-        """Define the signature of the request method."""
+        ...
 
     def __call__(
         self, api_commands: Command[T] | list[Command[T]], timeout: int | None = None
@@ -126,13 +126,13 @@ class APIFactory:
 
     @overload
     def request(self, api_commands: Command[T], timeout: int | None = None) -> T:
-        """Make a request. Timeout is in seconds."""
+        ...
 
     @overload
     def request(
         self, api_commands: list[Command[T]], timeout: int | None = None
     ) -> list[T]:
-        """Make a request. Timeout is in seconds."""
+        ...
 
     def request(
         self, api_commands: Command[T] | list[Command[T]], timeout: int | None = None

--- a/pytradfri/device/air_purifier.py
+++ b/pytradfri/device/air_purifier.py
@@ -93,8 +93,7 @@ class AirPurifier:
 
     @property
     def filter_status(self) -> bool:
-        """
-        Return True if filter needs to be replaced.
+        """Return True if filter needs to be replaced.
 
         This property is true when filter_lifetime_remaining is less than zero.
         """
@@ -102,8 +101,7 @@ class AirPurifier:
 
     @property
     def is_auto_mode(self) -> bool:
-        """
-        Return auto mode on or off.
+        """Return auto mode on or off.
 
         Auto mode sets the fan speed automatically based on the air quality.
         """

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -63,7 +63,7 @@ class GatewayInfoResponse(BaseModel):
 
 
 class Gateway:
-    """This class connects to the IKEA Tradfri Gateway."""
+    """IKEA Tradfri Gateway specific methods and properties."""
 
     @classmethod
     def generate_psk(cls, identity: str) -> Command[str]:
@@ -84,8 +84,7 @@ class Gateway:
 
     @classmethod
     def get_endpoints(cls) -> Command[list[str]]:
-        """
-        Return all available endpoints on the gateway.
+        """Return all available endpoints on the gateway.
 
         The response from the gateway looks like this:
         <//15006>;ct=0;obs,
@@ -121,8 +120,7 @@ class Gateway:
         )
 
     def get_devices(self) -> Command[list[Command[Device]]]:
-        """
-        Return the devices linked to the gateway.
+        """Return the devices linked to the gateway.
 
         Returns a Command.
         """
@@ -134,8 +132,7 @@ class Gateway:
 
     @classmethod
     def get_device(cls, device_id: str) -> Command[Device]:
-        """
-        Return specified device.
+        """Return specified device.
 
         Returns a Command.
         """
@@ -146,8 +143,7 @@ class Gateway:
         return Command("get", [ROOT_DEVICES, device_id], process_result=process_result)
 
     def get_groups(self) -> Command[list[Command[Group]]]:
-        """
-        Return the groups linked to the gateway.
+        """Return the groups linked to the gateway.
 
         Returns a Command.
         """
@@ -158,8 +154,7 @@ class Gateway:
         return Command("get", [ROOT_GROUPS], process_result=process_result)
 
     def get_group(self, group_id: str) -> Command[Group]:
-        """
-        Return specified group.
+        """Return specified group.
 
         Returns a Command.
         """
@@ -181,8 +176,7 @@ class Gateway:
 
     @classmethod
     def get_gateway_info(cls) -> Command[GatewayInfo]:
-        """
-        Return the gateway info.
+        """Return the gateway info.
 
         Returns a Command.
         """
@@ -195,8 +189,7 @@ class Gateway:
         )
 
     def get_moods(self, group_id: int) -> Command[list[Command[Mood]]]:
-        """
-        Return moods available in given group.
+        """Return moods available in given group.
 
         Returns a Command.
         """
@@ -210,8 +203,7 @@ class Gateway:
 
     @classmethod
     def get_mood(cls, mood_id: str, *, mood_parent: int) -> Command[Mood]:
-        """
-        Return a mood.
+        """Return a mood.
 
         Returns a Command.
         """
@@ -227,8 +219,7 @@ class Gateway:
         )
 
     def get_smart_tasks(self) -> Command[list[Command[SmartTask]]]:
-        """
-        Return the transitions linked to the gateway.
+        """Return the transitions linked to the gateway.
 
         Returns a Command.
         """
@@ -239,8 +230,7 @@ class Gateway:
         return Command("get", [ROOT_SMART_TASKS], process_result=process_result)
 
     def get_smart_task(self, task_id: str) -> Command[SmartTask]:
-        """
-        Return specified transition.
+        """Return specified transition.
 
         Returns a Command.
         """
@@ -283,7 +273,7 @@ class Gateway:
 
 
 class GatewayInfo:
-    """This class contains Gateway information."""
+    """Gateway information."""
 
     raw: GatewayInfoResponse
 
@@ -385,8 +375,7 @@ class GatewayInfo:
         return Command("put", self.path, values)
 
     def update(self) -> Command[None]:
-        """
-        Update the info.
+        """Update the info.
 
         Returns a Command.
         """

--- a/pytradfri/group.py
+++ b/pytradfri/group.py
@@ -85,8 +85,7 @@ class Group(ApiResource):
 
     @property
     def member_ids(self) -> list[int]:
-        """
-        Members of this group.
+        """Members of this group.
 
         A group with devices will look like this:
         {"15002": {"9003": [65536, 65537]}}

--- a/pytradfri/resource.py
+++ b/pytradfri/resource.py
@@ -101,8 +101,7 @@ class ApiResource:
         return Command("put", self.path, values)
 
     def update(self) -> Command[None]:
-        """
-        Update the group.
+        """Update the group.
 
         Returns a Command.
         """

--- a/pytradfri/smart_task.py
+++ b/pytradfri/smart_task.py
@@ -423,8 +423,7 @@ class StartActionItemController:
         return self.set_values(command)
 
     def set_values(self, values: dict[str, dict[str, Any]]) -> Command[None]:
-        """
-        Set values on task control.
+        """Set values on task control.
 
         Returns a Command.
         """


### PR DESCRIPTION
The ignores in the examples files are related to these errors. Guess it's the same reason mentioned [here](https://github.com/home-assistant-libs/pytradfri/pull/651#discussion_r1125706884)?
```
(.venv) vscode ➜ /workspaces/pytradfri (ruff-d-rule) $ pylint pytradfri examples tests
************* Module pytradfri.__main__
pytradfri/__main__.py:80:33: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
pytradfri/__main__.py:89:30: E1136: Value 'groups' is unsubscriptable (unsubscriptable-object)
pytradfri/__main__.py:90:21: E1133: Non-iterable value groups is used in an iterating context (not-an-iterable)
pytradfri/__main__.py:105:24: E1133: Non-iterable value endpoints is used in an iterating context (not-an-iterable)
pytradfri/__main__.py:117:31: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
************* Module debug_info
examples/debug_info.py:133:15: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
examples/debug_info.py:141:29: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
examples/debug_info.py:158:16: E1133: Non-iterable value tasks is used in an iterating context (not-an-iterable)
examples/debug_info.py:170:17: E1133: Non-iterable value groups is used in an iterating context (not-an-iterable)
examples/debug_info.py:183:25: E1133: Non-iterable value groups is used in an iterating context (not-an-iterable)
examples/debug_info.py:187:20: E1133: Non-iterable value moods is used in an iterating context (not-an-iterable)
************* Module example_sync
examples/example_sync.py:119:29: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
examples/example_sync.py:154:29: E1133: Non-iterable value devices is used in an iterating context (not-an-iterable)
examples/example_sync.py:174:15: E1136: Value 'tasks' is unsubscriptable (unsubscriptable-object)
```