### PR TITLE
Fix request while protocol context is shutting down

### DIFF
--- a/tests/api/test_aiocoap_api.py
+++ b/tests/api/test_aiocoap_api.py
@@ -1,12 +1,18 @@
 """Test aiocoap API."""
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from aiocoap import Message
+from aiocoap import Context
+from aiocoap.credentials import CredentialsMap
+from aiocoap.error import Error
 import pytest
 
 from pytradfri.api.aiocoap_api import APIFactory
 from pytradfri.command import Command
+from pytradfri.error import ServerError
 
 
 class MockCode:
@@ -31,30 +37,17 @@ class MockResponse:
         return b'{"one": 1}'
 
 
-class MockProtocol:
+class MockRequest:
     """Mock Protocol."""
 
-    async def mock_response(self) -> Any:
-        """Return protocol response."""
-        return MockResponse()
+    def __init__(self, response: Callable[[], Awaitable]) -> None:
+        """Create the request."""
+        self._response = response
 
     @property
     def response(self) -> Any:
         """Return protocol response."""
-        return self.mock_response()
-
-
-class MockContext:
-    """Mock a context."""
-
-    def request(self, message: Message) -> MockProtocol:
-        """Request a protocol."""
-        return MockProtocol()
-
-
-async def mock_create_context() -> MockContext:
-    """Return a context."""
-    return MockContext()
+        return self._response()
 
 
 def process_result(result: Any) -> Any:
@@ -62,10 +55,39 @@ def process_result(result: Any) -> Any:
     return result
 
 
-async def test_request_returns_single(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test return single object."""
-    monkeypatch.setattr("aiocoap.Context.create_client_context", mock_create_context)
+@pytest.fixture(name="response")
+def response_fixture() -> AsyncMock:
+    """Mock response."""
+    return AsyncMock()
 
+
+@pytest.fixture(name="context")
+def context_fixture(response) -> MagicMock:
+    """Mock context."""
+    with patch(
+        "pytradfri.api.aiocoap_api.Context.create_client_context"
+    ) as create_client_context:
+        context = MagicMock(spec=Context)
+
+        async def create_context() -> MagicMock:
+            """Reset the context."""
+            response.return_value = MockResponse()
+            response.side_effect = None
+            context.serversite = None
+            context.request_interfaces = []
+            context.client_credentials = CredentialsMap()
+            context.server_credentials = CredentialsMap()
+            context.request.return_value = MockRequest(response=response)
+            context.shutdown.side_effect = None
+            return context
+
+        create_client_context.side_effect = create_context
+        context.create_client_context = create_client_context
+        yield context
+
+
+async def test_request_returns_single(context: MagicMock) -> None:
+    """Test return single object."""
     api = (await APIFactory.init("127.0.0.1")).request
 
     command: Command[dict[str, int]] = Command("", [""], process_result=process_result)
@@ -75,10 +97,8 @@ async def test_request_returns_single(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response == {"one": 1}
 
 
-async def test_request_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_request_returns_list(context: MagicMock) -> None:
     """Test return of lists."""
-    monkeypatch.setattr("aiocoap.Context.create_client_context", mock_create_context)
-
     api = (await APIFactory.init("127.0.0.1")).request
 
     command: Command[dict[str, int]] = Command("", [""], process_result=process_result)
@@ -87,3 +107,37 @@ async def test_request_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert isinstance(response, list)
     assert response == [{"one": 1}, {"one": 1}, {"one": 1}]
+
+
+async def test_context_shutdown_request(
+    context: MagicMock, response: AsyncMock
+) -> None:
+    """Test a request while context is shutting down."""
+    factory = await APIFactory.init("127.0.0.1", psk="test-psk")
+    shutdown_event = asyncio.Event()
+
+    async def mock_shutdown() -> None:
+        """Mock shutdown."""
+        response.side_effect = Exception("Context was shutdown")
+        await shutdown_event.wait()
+
+    context.shutdown.side_effect = mock_shutdown
+    response.side_effect = Error("Boom!")
+
+    request_task_1 = asyncio.create_task(
+        factory.request(Command("", [""], process_result=process_result))
+    )
+    await asyncio.sleep(0)
+    request_task_2 = asyncio.create_task(
+        factory.request(Command("", [""], process_result=process_result))
+    )
+    await asyncio.sleep(0)
+
+    shutdown_event.set()
+    with pytest.raises(ServerError):
+        await request_task_1
+    result = await request_task_2
+
+    assert context.shutdown.call_count == 1
+    assert context.request.call_count == 2
+    assert result == {"one": 1}


### PR DESCRIPTION
- If the protocol context is shutting down we're not allowed to make new requests with the context.
- Add a check if we're shutting down the protocol context when getting the context.
- This should fix reqeusts that are made after the protocol context has begun to shutdown but before the protocol context has completed the reset.
- Example stacktrace (first one):
https://github.com/home-assistant/core/issues/105004#issuecomment-1855475069
- Requests that are already in flight before the protocol context begins the shutdown are up to aiocoap to handle and flush.