### PR TITLE
Fix reset protocol on error during context shutdown

### DIFF
--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -129,12 +129,14 @@ class APIFactory:
 
             # Be responsible and clean up.
             protocol = await self._get_protocol(check_reset_lock=False)
-            await protocol.shutdown()
-            self._protocol = None
 
-            # The error callbacks are called when shutting down the protocol.
-            # Clear the saved callbacks
-            self._observations_err_callbacks.clear()
+            try:
+                await protocol.shutdown()
+            finally:
+                self._protocol = None
+                # The error callbacks are called when shutting down the protocol.
+                # Clear the saved callbacks
+                self._observations_err_callbacks.clear()
 
     async def shutdown(self, exc: Exception | None = None) -> None:
         """Shutdown the API events.


### PR DESCRIPTION
- If there's an error during protocol context shutdown we want to make sure the protocol context completes the reset, so that a new protocol context is created the next time the protocol context is needed.
- Example stacktrace (second one): https://github.com/home-assistant/core/issues/105004#issuecomment-1855475069

Needs https://github.com/home-assistant-libs/pytradfri/pull/814