### PR TITLE
Fix id typing

### DIFF
--- a/examples/example_pair.py
+++ b/examples/example_pair.py
@@ -13,6 +13,7 @@ Where <IP> is the address to your IKEA gateway. The first time
 running you will be asked to input the 'Security Code' found on
 the back of your IKEA gateway.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -125,9 +126,9 @@ async def run(shutdown: asyncio.Future[None]) -> None:
     # monitor the device list and give instructions
     #
 
-    last_devices: list[str] | None = None
+    last_devices: list[int] | None = None
 
-    def devices_updated(result: list[str]) -> None:
+    def devices_updated(result: list[int]) -> None:
         nonlocal last_devices
 
         if last_devices is None:
@@ -139,7 +140,7 @@ async def run(shutdown: asyncio.Future[None]) -> None:
 
         last_devices = result
 
-    async def new_device(device_id: str) -> None:
+    async def new_device(device_id: int) -> None:
         nonlocal commissioning
 
         print("New device, fetching details...", end="", flush=True)

--- a/pytradfri/gateway.py
+++ b/pytradfri/gateway.py
@@ -126,13 +126,13 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command[Device]]:
+        def process_result(result: list[int]) -> list[Command[Device]]:
             return [self.get_device(dev) for dev in result]
 
         return Command("get", [ROOT_DEVICES], process_result=process_result)
 
     @classmethod
-    def get_device(cls, device_id: str) -> Command[Device]:
+    def get_device(cls, device_id: int) -> Command[Device]:
         """Return specified device.
 
         Returns a Command.
@@ -141,7 +141,9 @@ class Gateway:
         def process_result(result: TypeRaw) -> Device:
             return Device(result)
 
-        return Command("get", [ROOT_DEVICES, device_id], process_result=process_result)
+        return Command(
+            "get", [ROOT_DEVICES, str(device_id)], process_result=process_result
+        )
 
     def get_groups(self) -> Command[list[Command[Group]]]:
         """Return the groups linked to the gateway.
@@ -149,12 +151,12 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command[Group]]:
+        def process_result(result: list[int]) -> list[Command[Group]]:
             return [self.get_group(group) for group in result]
 
         return Command("get", [ROOT_GROUPS], process_result=process_result)
 
-    def get_group(self, group_id: str) -> Command[Group]:
+    def get_group(self, group_id: int) -> Command[Group]:
         """Return specified group.
 
         Returns a Command.
@@ -163,7 +165,9 @@ class Gateway:
         def process_result(result: TypeRaw) -> Group:
             return Group(self, result)
 
-        return Command("get", [ROOT_GROUPS, group_id], process_result=process_result)
+        return Command(
+            "get", [ROOT_GROUPS, str(group_id)], process_result=process_result
+        )
 
     @classmethod
     def add_group_member(cls, values: dict[str, Any]) -> Command[None]:
@@ -195,7 +199,7 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command[Mood]]:
+        def process_result(result: list[int]) -> list[Command[Mood]]:
             return [self.get_mood(mood, mood_parent=group_id) for mood in result]
 
         return Command(
@@ -203,7 +207,7 @@ class Gateway:
         )
 
     @classmethod
-    def get_mood(cls, mood_id: str, *, mood_parent: int) -> Command[Mood]:
+    def get_mood(cls, mood_id: int, *, mood_parent: int) -> Command[Mood]:
         """Return a mood.
 
         Returns a Command.
@@ -214,7 +218,7 @@ class Gateway:
 
         return Command(
             "get",
-            [ROOT_MOODS, str(mood_parent), mood_id],
+            [ROOT_MOODS, str(mood_parent), str(mood_id)],
             mood_parent,
             process_result=process_result,
         )
@@ -225,12 +229,12 @@ class Gateway:
         Returns a Command.
         """
 
-        def process_result(result: list[str]) -> list[Command[SmartTask]]:
+        def process_result(result: list[int]) -> list[Command[SmartTask]]:
             return [self.get_smart_task(task) for task in result]
 
         return Command("get", [ROOT_SMART_TASKS], process_result=process_result)
 
-    def get_smart_task(self, task_id: str) -> Command[SmartTask]:
+    def get_smart_task(self, task_id: int) -> Command[SmartTask]:
         """Return specified transition.
 
         Returns a Command.
@@ -240,7 +244,7 @@ class Gateway:
             return SmartTask(self, result)
 
         return Command(
-            "get", [ROOT_SMART_TASKS, task_id], process_result=process_result
+            "get", [ROOT_SMART_TASKS, str(task_id)], process_result=process_result
         )
 
     @classmethod

--- a/pytradfri/group.py
+++ b/pytradfri/group.py
@@ -46,7 +46,7 @@ class GroupResponse(ApiResourceResponse):
     color_hex: str | None = Field(alias=ATTR_LIGHT_COLOR_HEX)
     dimmer: int = Field(alias=ATTR_LIGHT_DIMMER)
     group_members: dict[str, dict[str, list[int]]] = Field(alias=ATTR_GROUP_MEMBERS)
-    mood_id: str = Field(alias=ATTR_MOOD)
+    mood_id: int = Field(alias=ATTR_MOOD)
     state: int = Field(alias=ATTR_DEVICE_STATE)
 
 
@@ -100,21 +100,21 @@ class Group(ApiResource):
         return self.raw.group_members[ATTR_HS_LINK][ATTR_ID]
 
     @property
-    def mood_id(self) -> str:
+    def mood_id(self) -> int:
         """Active mood."""
         return self.raw.mood_id
 
     def members(self) -> list[Command[Device]]:
         """Return device objects of members of this group."""
-        return [self._gateway.get_device(str(dev)) for dev in self.member_ids]
+        return [self._gateway.get_device(dev) for dev in self.member_ids]
 
-    def add_member(self, memberid: str) -> Command[None]:
+    def add_member(self, memberid: int) -> Command[None]:
         """Add a member to this group."""
         return self._gateway.add_group_member(
             {ATTR_GROUP_ID: self.id, ATTR_ID: [memberid]}
         )
 
-    def remove_member(self, memberid: str) -> Command[None]:
+    def remove_member(self, memberid: int) -> Command[None]:
         """Remove a member from this group."""
         return self._gateway.remove_group_member(
             {ATTR_GROUP_ID: self.id, ATTR_ID: [memberid]}
@@ -128,7 +128,7 @@ class Group(ApiResource):
         """Active mood."""
         return self._gateway.get_mood(self.mood_id, mood_parent=self.id)
 
-    def activate_mood(self, mood_id: str) -> Command[None]:
+    def activate_mood(self, mood_id: int) -> Command[None]:
         """Activate a mood."""
         return self.set_values({ATTR_MOOD: mood_id, ATTR_DEVICE_STATE: int(self.state)})
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -50,7 +50,7 @@ def test_get_device(gateway):
     command = gateway.get_device(123)
 
     assert command.method == "get"
-    assert command.path == [ROOT_DEVICES, 123]
+    assert command.path == [ROOT_DEVICES, "123"]
 
 
 def test_gateway_info():


### PR DESCRIPTION
- The type of the different id parameters should always be an integer according to the data returned by the gateway. We had mistyped this parameter in some places as a string.
- Note that this is a breaking change as we change the type of some parameters in the Gateway methods.