### PR TITLE
Add missing type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ ignore_errors = true
 target-version = "py310"
 
 select = [
+    "ANN", # Missing type argument
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
     "C",  # complexity
@@ -148,6 +149,7 @@ select = [
 ]
 
 ignore = [
+    "ANN401", # any-type
     "D203",  # 1 blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
 ]

--- a/pytradfri/api/aiocoap_api.py
+++ b/pytradfri/api/aiocoap_api.py
@@ -64,7 +64,7 @@ class APIFactory:
         psk_id: str = "pytradfri",
         psk: str | None = None,
         internal_create: UndefinedType | None = None,
-    ):
+    ) -> None:
         """Create object of class."""
         if internal_create is not _SENTINEL:
             raise ValueError("Use APIFactory.init(…) to initialize APIFactory")

--- a/pytradfri/smart_task.py
+++ b/pytradfri/smart_task.py
@@ -293,7 +293,7 @@ class StartActionItem:
         state: bool,
         path: list[str],
         raw: RootStartActionResponse,
-    ):
+    ) -> None:
         """Initialize TaskInfo."""
         self.task = task
         self.index = index
@@ -371,7 +371,7 @@ class StartActionItemController:
         state: bool,
         path: list[str],
         devices_list: list[dict[str, int]],
-    ):
+    ) -> None:
         """Initialize StartActionItemController."""
         self._item = item
         self.raw = raw

--- a/tests/api/test_aiocoap_api.py
+++ b/tests/api/test_aiocoap_api.py
@@ -62,7 +62,7 @@ def response_fixture() -> AsyncMock:
 
 
 @pytest.fixture(name="context")
-def context_fixture(response: AsyncMock) -> Generator[MagicMock, None, None]:
+def context_fixture(response: AsyncMock) -> Generator[MagicMock]:
     """Mock context."""
     with patch(
         "pytradfri.api.aiocoap_api.Context.create_client_context"

--- a/tests/api/test_aiocoap_api.py
+++ b/tests/api/test_aiocoap_api.py
@@ -1,7 +1,7 @@
 """Test aiocoap API."""
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -40,7 +40,7 @@ class MockResponse:
 class MockRequest:
     """Mock Protocol."""
 
-    def __init__(self, response: Callable[[], Awaitable]) -> None:
+    def __init__(self, response: Callable[[], Awaitable[Any]]) -> None:
         """Create the request."""
         self._response = response
 
@@ -62,7 +62,7 @@ def response_fixture() -> AsyncMock:
 
 
 @pytest.fixture(name="context")
-def context_fixture(response) -> MagicMock:
+def context_fixture(response: AsyncMock) -> Generator[MagicMock, None, None]:
     """Mock context."""
     with patch(
         "pytradfri.api.aiocoap_api.Context.create_client_context"

--- a/tests/api/test_libcoap_api.py
+++ b/tests/api/test_libcoap_api.py
@@ -1,16 +1,21 @@
 """Test API utilities."""
 
 import json
+from typing import Any
+
+import pytest
 
 from pytradfri.api.libcoap_api import APIFactory
 from pytradfri.gateway import Gateway
 
 
-def test_constructor_timeout_passed_to_subprocess(monkeypatch):
+def test_constructor_timeout_passed_to_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test that original timeout is passed to subprocess."""
     capture = {}
 
-    def capture_args(*args, **kwargs):
+    def capture_args(*args: Any, **kwargs: Any) -> str:
         capture.update(kwargs)
         return json.dumps([])
 
@@ -21,11 +26,11 @@ def test_constructor_timeout_passed_to_subprocess(monkeypatch):
     assert capture["timeout"] == 20
 
 
-def test_custom_timeout_passed_to_subprocess(monkeypatch):
+def test_custom_timeout_passed_to_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that custom timeout is passed to subprocess."""
     capture = {}
 
-    def capture_args(*args, **kwargs):
+    def capture_args(*args: Any, **kwargs: Any) -> str:
         capture.update(kwargs)
         return json.dumps([])
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -29,7 +29,7 @@ MIN_KELVIN_WS = 2200
 MAX_KELVIN_WS = 4000
 
 
-def test_supported_colors():
+def test_supported_colors() -> None:
     """Test supported colors."""
     assert (
         supported_features(LightResponse(**LIGHT_W[ATTR_LIGHT_CONTROL][0]))

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -3,10 +3,10 @@
 from pytradfri.command import Command
 
 
-def test_property_access():
+def test_property_access() -> None:
     """Test property access in Command."""
 
-    def error_callback():
+    def error_callback() -> None:
         pass
 
     command = Command(
@@ -27,10 +27,10 @@ def test_property_access():
     assert command.err_callback is error_callback
 
 
-def test_result():
+def test_result() -> None:
     """Test callback process_result."""
 
-    def process_result(value):
+    def process_result(value: int) -> int:
         return value + 1
 
     command = Command("method", "path", {}, process_result=process_result)
@@ -42,7 +42,7 @@ def test_result():
     assert command.raw_result == 0
 
 
-def test_url():
+def test_url() -> None:
     """Test url is recognized."""
     command = Command("method", ["path"], {})
     url = command.url("host")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -6,12 +6,12 @@ from pytradfri.command import Command
 def test_property_access() -> None:
     """Test property access in Command."""
 
-    def error_callback() -> None:
+    def error_callback(err: Exception) -> None:
         pass
 
-    command = Command(
+    command: Command[None] = Command(
         method="method",
-        path="path",
+        path=["path"],
         data="data",
         parse_json=True,
         observe=False,
@@ -20,7 +20,7 @@ def test_property_access() -> None:
     )
 
     assert command.method == "method"
-    assert command.path == "path"
+    assert command.path == ["path"]
     assert command.parse_json is True
     assert command.observe is False
     assert command.observe_duration == 0
@@ -33,9 +33,9 @@ def test_result() -> None:
     def process_result(value: int) -> int:
         return value + 1
 
-    command = Command("method", "path", {}, process_result=process_result)
+    command = Command("method", ["path"], {}, process_result=process_result)
     assert command.result is None
-    assert command.raw_result is None
+    assert command.raw_result is None  # type: ignore[unreachable]
 
     command.process_result(0)
     assert command.result == 1
@@ -44,10 +44,10 @@ def test_result() -> None:
 
 def test_url() -> None:
     """Test url is recognized."""
-    command = Command("method", ["path"], {})
+    command: Command[None] = Command("method", ["path"], {})
     url = command.url("host")
     assert url == "coaps://host:5684/path"
 
-    command2 = Command("method", ["path1", "path2"], {})
+    command2: Command[None] = Command("method", ["path1", "path2"], {})
     url = command2.url("host")
     assert url == "coaps://host:5684/path1/path2"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -294,8 +295,12 @@ lamp_value_setting_test_cases[1] = new_list
 
 @pytest.mark.parametrize(*lamp_value_setting_test_cases)
 def test_lamp_value_setting(
-    function_name, comment, test_input, expected_result, device
-):
+    function_name: str,
+    comment: str,
+    test_input: dict[str, Any],
+    expected_result: dict[str, Any],
+    device: Device,
+) -> None:
     """Test lamp value."""
     function = getattr(device[1].light_control, function_name)
     command = function(**test_input)
@@ -328,7 +333,12 @@ def test_lamp_value_setting(
         ],
     ],
 )
-def test_socket_value_setting(function_name, comment, test_input, expected_result):
+def test_socket_value_setting(
+    function_name: str,
+    comment: str,
+    test_input: dict[str, bool],
+    expected_result: dict[str, bool],
+) -> None:
     """Test socket values."""
     function = getattr(Device(deepcopy(OUTLET)).socket_control, function_name)
     command = function(**test_input)
@@ -336,7 +346,7 @@ def test_socket_value_setting(function_name, comment, test_input, expected_resul
     assert data == expected_result
 
 
-def test_socket_state_off():
+def test_socket_state_off() -> None:
     """Test socket off."""
     socket_response = deepcopy(OUTLET)
     socket_response[ATTR_SWITCH_PLUG][0][ATTR_DEVICE_STATE] = 0
@@ -345,7 +355,7 @@ def test_socket_state_off():
     assert socket.state is False
 
 
-def test_socket_state_on():
+def test_socket_state_on() -> None:
     """Test socket on."""
     socket_response = deepcopy(OUTLET)
     socket_response[ATTR_SWITCH_PLUG][0][ATTR_DEVICE_STATE] = 1
@@ -354,13 +364,13 @@ def test_socket_state_on():
     assert socket.state is True
 
 
-def test_set_predefined_color_invalid(device):
+def test_set_predefined_color_invalid(device: Device) -> None:
     """Test set invalid color."""
     with pytest.raises(error.ColorError):
         device.light_control.set_predefined_color("RandomString")
 
 
-def test_device_properties(device):
+def test_device_properties(device: Device) -> None:
     """Test device properties."""
     assert device.application_type == 2
     assert device.name == "Löng name containing viking lättårs [letters]"
@@ -370,7 +380,7 @@ def test_device_properties(device):
     assert device.path == [ROOT_DEVICES, "65539"]
 
 
-def test_device_info_properties(device):
+def test_device_info_properties(device: Device) -> None:
     """Test device info."""
     info = device.device_info
 
@@ -384,12 +394,12 @@ def test_device_info_properties(device):
 @pytest.mark.parametrize(
     "device", [DEVICE_WITHOUT_FIRMWARE_VERSION], indirect=["device"]
 )
-def test_device_without_firmware_version(device):
+def test_device_without_firmware_version(device: Device) -> None:
     """Test device without firmware version."""
     assert device.device_info.firmware_version is None
 
 
-def test_set_name(device):
+def test_set_name(device: Device) -> None:
     """Test set name."""
     command = device.set_name("New name")
 
@@ -398,7 +408,7 @@ def test_set_name(device):
     assert command.data == {ATTR_NAME: "New name"}
 
 
-def test_binary_division():
+def test_binary_division() -> None:
     """Test binary division."""
     dev_ws = Device(LIGHT_WS).light_control.lights[0]
     dev_color = Device(LIGHT_CWS).light_control.lights[0]
@@ -410,7 +420,7 @@ def test_binary_division():
 
 
 # Test has_light_control function
-def test_has_light_control_true():
+def test_has_light_control_true() -> None:
     """Test light has control."""
     response = deepcopy(LIGHT_WS)
     dev = Device(response)
@@ -418,7 +428,7 @@ def test_has_light_control_true():
     assert dev.has_light_control is True
 
 
-def test_has_light_control_false():
+def test_has_light_control_false() -> None:
     """Test light do not have control."""
     response = deepcopy(LIGHT_WS)
     response.pop(ATTR_LIGHT_CONTROL)
@@ -428,7 +438,7 @@ def test_has_light_control_false():
 
 
 # Test light state function
-def test_light_state_on():
+def test_light_state_on() -> None:
     """Test light on."""
     device_data = deepcopy(LIGHT_WS)
     device_data[ATTR_LIGHT_CONTROL][0][ATTR_DEVICE_STATE] = 1
@@ -437,7 +447,7 @@ def test_light_state_on():
     assert light.state is True
 
 
-def test_light_state_off():
+def test_light_state_off() -> None:
     """Test light off."""
     device_data = deepcopy(LIGHT_WS)
     device_data[ATTR_LIGHT_CONTROL][0][ATTR_DEVICE_STATE] = 0
@@ -446,7 +456,7 @@ def test_light_state_off():
     assert light.state is False
 
 
-def test_light_state_mangled():
+def test_light_state_mangled() -> None:
     """Test mangled light state."""
     device_data = deepcopy(LIGHT_WS)
     device_data[ATTR_LIGHT_CONTROL][0][ATTR_DEVICE_STATE] = "RandomString"
@@ -457,7 +467,7 @@ def test_light_state_mangled():
 
 
 # Test light hsb_xy_color function
-def test_light_hsb_xy_color():
+def test_light_hsb_xy_color() -> None:
     """Very basic test, just to touch it."""
     device_data = deepcopy(LIGHT_CWS)
     device = Device(device_data)
@@ -466,12 +476,12 @@ def test_light_hsb_xy_color():
 
 
 # Test last_seen function
-def test_last_seen_valid(device):
+def test_last_seen_valid(device: Device) -> None:
     """Test last seen."""
     assert device.last_seen is not None
 
 
-def test_last_seen_none():
+def test_last_seen_none() -> None:
     """Test last seen none."""
     response = deepcopy(LIGHT_WS)
     del response[ATTR_LAST_SEEN]
@@ -480,7 +490,7 @@ def test_last_seen_none():
 
 
 # Test _value_validate function
-def test_value_validate_lower_edge(device):
+def test_value_validate_lower_edge(device: Device) -> None:
     """Test value lower edge."""
     # pylint: disable=protected-access
     rnge = (10, 100)
@@ -490,7 +500,7 @@ def test_value_validate_lower_edge(device):
     assert device.light_control._value_validate(11, rnge) is None
 
 
-def test_value_validate_upper_edge(device):
+def test_value_validate_upper_edge(device: Device) -> None:
     """Test value upper edge."""
     # pylint: disable=protected-access
     rnge = (10, 100)
@@ -500,7 +510,7 @@ def test_value_validate_upper_edge(device):
         device.light_control._value_validate(101, rnge)
 
 
-def test_value_validate_none(device):
+def test_value_validate_none(device: Device) -> None:
     """Test value none."""
     # pylint: disable=protected-access
     rnge = (10, 100)
@@ -508,7 +518,7 @@ def test_value_validate_none(device):
 
 
 # Test deviceInfo serial function
-def test_device_info_serial():
+def test_device_info_serial() -> None:
     """Test serial number."""
     response = deepcopy(LIGHT_WS)
     response[ATTR_DEVICE_INFO]["2"] = "SomeRandomSerial"
@@ -518,14 +528,14 @@ def test_device_info_serial():
 
 
 # Test deviceInfo power_source_str function
-def test_device_info_power_source_str_known():
+def test_device_info_power_source_str_known() -> None:
     """Test power source known."""
     info = Device(deepcopy(LIGHT_WS)).device_info
     assert info.power_source_str is not None
     assert info.power_source_str != "Unknown"
 
 
-def test_device_info_power_source_str_unknown():
+def test_device_info_power_source_str_unknown() -> None:
     """Test power source unknown."""
     response = deepcopy(LIGHT_WS)
     response[ATTR_DEVICE_INFO]["6"] = 99999
@@ -534,7 +544,7 @@ def test_device_info_power_source_str_unknown():
     assert info.power_source_str == "Unknown"
 
 
-def test_device_info_power_source_not_present():
+def test_device_info_power_source_not_present() -> None:
     """Test power source not present."""
     response = deepcopy(LIGHT_WS)
     del response[ATTR_DEVICE_INFO]["6"]
@@ -554,7 +564,9 @@ def test_device_info_battery_level(comment: str, device: Device) -> None:
 
 
 @pytest.mark.parametrize(*input_devices)
-def test_device_info_battery_level_unknown(comment: str, device: Device) -> None:
+def test_device_info_battery_level_unknown(
+    comment: str, device: dict[str, Any]
+) -> None:
     """Test battery level unknown."""
     response = deepcopy(device)
     response[ATTR_DEVICE_INFO].pop("9")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -40,12 +40,12 @@ GATEWAY_INFO = {
 
 
 @pytest.fixture(name="gateway")
-def gateway_fixture():
+def gateway_fixture() -> Gateway:
     """Fixture that returns a gateway."""
     return Gateway()
 
 
-def test_get_device(gateway):
+def test_get_device(gateway: Gateway) -> None:
     """Test get device."""
     command = gateway.get_device(123)
 
@@ -53,7 +53,7 @@ def test_get_device(gateway):
     assert command.path == [ROOT_DEVICES, "123"]
 
 
-def test_gateway_info():
+def test_gateway_info() -> None:
     """Test retrieval of gateway info."""
     gateway_info = GatewayInfo(GATEWAY_INFO)
 
@@ -79,7 +79,7 @@ def test_gateway_info():
     assert gateway_info_empty.first_setup is None
 
 
-def test_generate_psk(gateway):
+def test_generate_psk(gateway: Gateway) -> None:
     """Test psk generation."""
     command = gateway.generate_psk("identityString")
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -4,6 +4,7 @@ import pytest
 
 from pytradfri import error
 from pytradfri.device import Device
+from pytradfri.device.light import Light
 from pytradfri.resource import TypeRaw
 
 from .devices import (
@@ -15,9 +16,11 @@ from .devices import (
 )
 
 
-def light(raw: TypeRaw) -> Device:
+def light(raw: TypeRaw) -> Light:
     """Return Light."""
-    return Device(raw).light_control.lights[0]
+    light_control = Device(raw).light_control
+    assert light_control is not None
+    return light_control.lights[0]
 
 
 def test_white_bulb() -> None:
@@ -88,11 +91,15 @@ def test_color_bulb_custom_color() -> None:
 
 def test_setters() -> None:
     """Test light setters."""
-    cmd = Device(LIGHT_CWS).light_control.set_predefined_color("Warm glow")
+    light_control = Device(LIGHT_CWS).light_control
+    assert light_control is not None
+    cmd = light_control.set_predefined_color("Warm glow")
     assert cmd.data == {"3311": [{"5706": "efd275"}]}
 
+    light_control = Device(LIGHT_CWS).light_control
+    assert light_control is not None
     with pytest.raises(error.ColorError):
-        Device(LIGHT_CWS).light_control.set_predefined_color("Ggravlingen")
+        light_control.set_predefined_color("Ggravlingen")
 
 
 def test_combine_command() -> None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -4,6 +4,7 @@ import pytest
 
 from pytradfri import error
 from pytradfri.device import Device
+from pytradfri.resource import TypeRaw
 
 from .devices import (
     LIGHT_CWS,
@@ -14,12 +15,12 @@ from .devices import (
 )
 
 
-def light(raw):
+def light(raw: TypeRaw) -> Device:
     """Return Light."""
     return Device(raw).light_control.lights[0]
 
 
-def test_white_bulb():
+def test_white_bulb() -> None:
     """Test white bulb."""
     bulb = light(LIGHT_W)
 
@@ -32,7 +33,7 @@ def test_white_bulb():
     assert not bulb.supports_hsb_xy_color
 
 
-def test_spectrum_bulb():
+def test_spectrum_bulb() -> None:
     """Test spectrum bulb."""
     bulb = light(LIGHT_WS)
 
@@ -46,7 +47,7 @@ def test_spectrum_bulb():
     assert not bulb.supports_hsb_xy_color
 
 
-def test_spectrum_bulb_custom_color():
+def test_spectrum_bulb_custom_color() -> None:
     """Test spectrum custom color."""
     bulb = light(LIGHT_WS_CUSTOM_COLOR)
 
@@ -59,7 +60,7 @@ def test_spectrum_bulb_custom_color():
     assert not bulb.supports_hsb_xy_color
 
 
-def test_color_bulb():
+def test_color_bulb() -> None:
     """Test color."""
     bulb = light(LIGHT_CWS)
 
@@ -72,7 +73,7 @@ def test_color_bulb():
     assert bulb.supports_hsb_xy_color
 
 
-def test_color_bulb_custom_color():
+def test_color_bulb_custom_color() -> None:
     """Test custom color."""
     bulb = light(LIGHT_CWS_CUSTOM_COLOR)
 
@@ -85,7 +86,7 @@ def test_color_bulb_custom_color():
     assert bulb.supports_hsb_xy_color
 
 
-def test_setters():
+def test_setters() -> None:
     """Test light setters."""
     cmd = Device(LIGHT_CWS).light_control.set_predefined_color("Warm glow")
     assert cmd.data == {"3311": [{"5706": "efd275"}]}
@@ -94,7 +95,7 @@ def test_setters():
         Device(LIGHT_CWS).light_control.set_predefined_color("Ggravlingen")
 
 
-def test_combine_command():
+def test_combine_command() -> None:
     """Test light control combine command."""
     device = Device(LIGHT_CWS)
 

--- a/tests/test_mood.py
+++ b/tests/test_mood.py
@@ -9,11 +9,11 @@ from .moods import MOOD
 
 
 @pytest.fixture(name="mood")
-def mood_fixture():
+def mood_fixture() -> Mood:
     """Return Mood object."""
     return Mood(MOOD, 131080)
 
 
-def test_mood_properties(mood):
+def test_mood_properties(mood: Mood) -> None:
     """Test properties of mood."""
     assert mood.path == [ROOT_MOODS, "131080", "196625"]

--- a/tests/test_signal_repeater.py
+++ b/tests/test_signal_repeater.py
@@ -5,7 +5,7 @@ from pytradfri.device import Device
 from tests.devices import SIGNAL_REPEATER
 
 
-def test_properties():
+def test_properties() -> None:
     """Test that we can fetch attributes of the signal repeater."""
     device = Device(SIGNAL_REPEATER)
     signal_repeater = device.signal_repeater_control.signal_repeaters[0]

--- a/tests/test_smart_task.py
+++ b/tests/test_smart_task.py
@@ -82,7 +82,7 @@ WEEKDAYS = BitChoices(
 )
 
 
-def test_smart_task():
+def test_smart_task() -> None:
     """Test smart task."""
     gateway = Gateway()
     task = SmartTask(gateway, TASK)
@@ -103,7 +103,7 @@ def test_smart_task():
     assert task2.task_type_name == "Not At Home"
 
 
-def test_smart_task_info():
+def test_smart_task_info() -> None:
     """Test gateway info."""
     gateway = Gateway()
 
@@ -112,12 +112,12 @@ def test_smart_task_info():
     assert task.dimmer == 254
 
 
-def test_smart_task_bit_choices():
+def test_smart_task_bit_choices() -> None:
     """Test smart task with bit choices."""
     assert WEEKDAYS.get_selected_values(3) == ["Monday", "Tuesday"]
 
 
-def test_smart_task_set_state():
+def test_smart_task_set_state() -> None:
     """Test smart task set state."""
     gateway = Gateway()
     task_control = SmartTask(gateway, TASK).task_control
@@ -129,7 +129,7 @@ def test_smart_task_set_state():
     assert cmd.data == {"5850": 0, "9001": "Sample Name"}
 
 
-def test_optional_dimmer():
+def test_optional_dimmer() -> None:
     """Test a smart task with missing dimmer attribute."""
     gateway = Gateway()
     task = SmartTask(gateway, TASK_OPTIONAL_DIMMER).task_control.tasks[0]

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -1,16 +1,17 @@
 """Test Socket."""
 
 from pytradfri.device import Device
+from pytradfri.resource import TypeRaw
 
 from .devices import OUTLET
 
 
-def socket(raw):
+def socket(raw: TypeRaw) -> Device:
     """Return socket."""
     return Device(raw).socket_control.sockets[0]
 
 
-def test_socket():
+def test_socket() -> None:
     """Test socket."""
     plug = socket(OUTLET)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ from pytradfri.util import BitChoices, load_json, save_json
 class UtilTestsBitChoices(unittest.TestCase):
     """Utility bit choices."""
 
-    def test_bitchoices(self):
+    def test_bitchoices(self) -> None:
         """Test bit choices."""
         weekdays = BitChoices((("tue", "Tuesday"),))
 
@@ -28,15 +28,15 @@ class UtilTestsBitChoices(unittest.TestCase):
 class UtilTestsJSON(unittest.TestCase):
     """Utility JSON."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Create test suite."""
         self.test_dir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         """Teardown test suite."""
         shutil.rmtree(self.test_dir)
 
-    def test_json_save(self):
+    def test_json_save(self) -> None:
         """Test json save."""
         filename = path.join(self.test_dir, "sample_psk_file.txt")
         conf = {"identity": "pytradfri", "key": "123abc"}
@@ -44,7 +44,7 @@ class UtilTestsJSON(unittest.TestCase):
         written_file = save_json(filename, conf)
         self.assertTrue(written_file)
 
-    def test_json_load(self):
+    def test_json_load(self) -> None:
         """Test json load."""
         config = {"identity": "hashstring", "key": "secretkey"}
         data = json.dumps(config, sort_keys=True, indent=4)
@@ -56,11 +56,11 @@ class UtilTestsJSON(unittest.TestCase):
         json_data = load_json(path.join(self.test_dir, "sample_psk_file2.txt"))
         self.assertEqual(json_data, {"identity": "hashstring", "key": "secretkey"})
 
-    def test_load_file_not_found(self):
+    def test_load_file_not_found(self) -> None:
         """Test json file missing."""
         assert not load_json(path.join(self.test_dir, "not_a_file"))
 
-    def test_load_not_json(self):
+    def test_load_not_json(self) -> None:
         """Test of load not json."""
         data = "{not valid json"
         with open(
@@ -71,14 +71,14 @@ class UtilTestsJSON(unittest.TestCase):
         with pytest.raises(PytradfriError):
             load_json(path.join(self.test_dir, "sample_psk_file3.txt"))
 
-    def test_save_not_serializable(self):
+    def test_save_not_serializable(self) -> None:
         """Test save of illegal path."""
         filename = path.join(self.test_dir, "should_not_save")
         conf = b"bytes are not serializable"
         with pytest.raises(PytradfriError):
             save_json(filename, conf)
 
-    def test_os_error(self):
+    def test_os_error(self) -> None:
         """Test os error is thrown."""
         with patch("builtins.open", side_effect=OSError(-1)):
             with pytest.raises(PytradfriError):


### PR DESCRIPTION
- Add missing type annotations found by the ANN ruff linter setting group.
- https://docs.astral.sh/ruff/rules/#flake8-annotations-ann